### PR TITLE
Send elastic cluster health to riemann.

### DIFF
--- a/logsearch-jobs.yml
+++ b/logsearch-jobs.yml
@@ -11,6 +11,8 @@ meta:
     release: logsearch
   - name: curator
     release: logsearch
+  - name: riemann-emitter
+    release: riemann
 
   elasticsearch_data_templates:
   - name: elasticsearch
@@ -122,6 +124,12 @@ properties:
     admin_username: (( merge ))
     admin_password: "(( merge ))"
     admin_client_secret: "(( merge ))"
+  riemann_emitter:
+    host: (( merge ))
+    port: (( merge ))
+    elastic:
+      host: (( merge ))
+      port: (( merge ))
 
 jobs:
 - name: elasticsearch_master

--- a/secrets.example.yml
+++ b/secrets.example.yml
@@ -26,6 +26,12 @@ properties:
     user: nats
     password: nats
     machines: nats
+  riemann_emitter:
+    host: localhost
+    port: 5555
+    elastic:
+      host: localhost
+      port: 9200
 
 networks:
 - name: default


### PR DESCRIPTION
Add the `riemann-emitter` job and merge the associated properties from secrets. See https://github.com/18F/cg-riemann-boshrelease/blob/master/jobs/riemann-emitter/spec#L26-L31.