### PR TITLE
Upload riemann release on deploy.

### DIFF
--- a/pipeline.yml
+++ b/pipeline.yml
@@ -9,6 +9,7 @@ jobs:
     - get: common-prod
       trigger: true
     - get: cg-s3-logsearch-release
+    - get: cg-s3-riemann-release
     - get: logsearch-stemcell
     - get: upstream-logsearch-release
   - task: logsearch-manifest
@@ -32,6 +33,7 @@ jobs:
       manifest: logsearch-manifest/manifest.yml
       releases:
         - cg-s3-logsearch-release/*.tgz
+        - cg-s3-riemann-release/*.tgz
         - upstream-logsearch-release/*.tgz
       stemcells:
         - logsearch-stemcell/*.tgz
@@ -116,6 +118,16 @@ resources:
     regexp: logsearch-boshrelease-(.*).tgz
     region_name: {{aws-region}}
     secret_access_key: {{ci-secret-access-key}}
+
+- name: cg-s3-riemann-release
+  type: s3
+  source:
+    access_key_id: {{ci-access-key-id}}
+    bucket: {{cg-s3-bosh-releases-bucket}}
+    private: true
+    regexp: riemann-(.*).tgz
+    secret_access_key: {{ci-secret-access-key}}
+    region_name: {{aws-region}}
 
 - name: logsearch-config
   type: git


### PR DESCRIPTION
This is necessary now that the logsearch deploy uses a handful of jobs
from the riemann release (riemann-emitter, riemann-checklogs).