### PR TITLE
Apply logstash patch to cluster monitor job.

### DIFF
--- a/logsearch-infrastructure-aws.yml
+++ b/logsearch-infrastructure-aws.yml
@@ -51,6 +51,7 @@ resource_pools:
   cloud_properties:
     availability_zone: (( grab meta.aws.availability_zone ))
     instance_type: m3.xlarge
+    iam_instance_profile: logsearch-ingestor
 
 - name: haproxy
   cloud_properties:

--- a/logsearch-jobs.yml
+++ b/logsearch-jobs.yml
@@ -32,6 +32,7 @@ jobs:
   - {release: logsearch, name: curator}
   - {release: logsearch, name: kibana}
   - {release: logsearch, name: nats_to_syslog}
+  - {name: apply-patch, release: logstash-output-s3-backport}
   resource_pool: cluster_monitor
   networks:
   - name: default


### PR DESCRIPTION
The `cluster_monitor` job runs the ingestor jobs, so it also needs the logstash s3 output patch and the logging iam role. This seems to be why we've been getting all the pages about this job failing.

@cnelson 