### PR TITLE
Ship firehose to cloudwatch.

### DIFF
--- a/logsearch-jobs.yml
+++ b/logsearch-jobs.yml
@@ -276,19 +276,27 @@ properties:
     elasticsearch:
       host: (( grab jobs.elasticsearch_master.networks.default.static_ips.[0] ))
       port: 9200
+  logstash:
+    plugins:
+    - {name: logstash-output-cloudwatchlogs-latest, version: 2.0.0.pre1}
   logstash_parser:
     debug: false
   logstash_ingestor:
     debug: false
     outputs:
-      - plugin: redis
-        options: {}
-      - plugin: s3
-        options:
-          region: (( grab meta.aws.region ))
-          bucket: (( grab meta.ingestor.bucket ))
-          time_file: 5
-          server_side_encryption: true
+    - plugin: redis
+      options: {}
+    - plugin: s3
+      options:
+        region: (( grab meta.aws.region ))
+        bucket: (( grab meta.ingestor.bucket ))
+        time_file: 5
+        server_side_encryption: true
+    - plugin: cloudwatchlogs
+      options:
+        region: (( grab meta.aws.region ))
+        log_group_name: (( concat "logsearch-" meta.env ))
+        log_stream_name: "firehose-%instance_id%"
   redis:
     host: (( grab jobs.queue.networks.default.static_ips.[0] ))
   elasticsearch:
@@ -308,9 +316,9 @@ properties:
     - index_template: /var/vcap/packages/logsearch-config/default-mappings.json
   snort:
     rules:
-      - 'alert tcp any any -> any 9200 (msg:"Unexpected logsearch action"; content:"POST"; http_method; content: "logs-app"; http_uri; content:"/_update"; http_uri; classtype:web-application-attack; sid:343080002; rev:1;)'
-      - 'alert tcp any any -> any 9200 (msg:"Unexpected logsearch action"; content:"POST"; http_method; content: "logs-platform"; http_uri; content:"/_update"; http_uri; classtype:web-application-attack; sid:343080003; rev:1;)'
-      - 'alert tcp any any -> any 9200 (msg:"Unexpected logsearch action"; content:"DELETE"; http_method; content: "logs-app"; http_uri; classtype:web-application-attack; sid:343080004; rev:1;)'
-      - (( concat "suppress gen_id 1, sig_id 343080004, track by_src, ip " jobs.cluster_monitor.networks.default.static_ips.[0] ))
-      - 'alert tcp any any -> any 9200 (msg:"Unexpected logsearch action"; content:"DELETE"; http_method; content: "logs-platform"; http_uri; classtype:web-application-attack; sid:343080005; rev:1;)'
-      - (( concat "suppress gen_id 1, sig_id 343080005, track by_src, ip " jobs.cluster_monitor.networks.default.static_ips.[0] ))
+    - 'alert tcp any any -> any 9200 (msg:"Unexpected logsearch action"; content:"POST"; http_method; content: "logs-app"; http_uri; content:"/_update"; http_uri; classtype:web-application-attack; sid:343080002; rev:1;)'
+    - 'alert tcp any any -> any 9200 (msg:"Unexpected logsearch action"; content:"POST"; http_method; content: "logs-platform"; http_uri; content:"/_update"; http_uri; classtype:web-application-attack; sid:343080003; rev:1;)'
+    - 'alert tcp any any -> any 9200 (msg:"Unexpected logsearch action"; content:"DELETE"; http_method; content: "logs-app"; http_uri; classtype:web-application-attack; sid:343080004; rev:1;)'
+    - (( concat "suppress gen_id 1, sig_id 343080004, track by_src, ip " jobs.cluster_monitor.networks.default.static_ips.[0] ))
+    - 'alert tcp any any -> any 9200 (msg:"Unexpected logsearch action"; content:"DELETE"; http_method; content: "logs-platform"; http_uri; classtype:web-application-attack; sid:343080005; rev:1;)'
+    - (( concat "suppress gen_id 1, sig_id 343080005, track by_src, ip " jobs.cluster_monitor.networks.default.static_ips.[0] ))


### PR DESCRIPTION
Install and configure logstash-output-cloudwatchlogs plugin and ship logs to cloudwatch, namespaced by instance id. Requires https://github.com/cloudfoundry-community/logsearch-boshrelease/pull/5.