### PR TITLE
Use route_registrar job from cf release to register logsearch with the go router

### DIFF
--- a/logsearch-jobs.yml
+++ b/logsearch-jobs.yml
@@ -195,6 +195,7 @@ jobs:
   instances: 1
   templates:
   - { name: haproxy, release: logsearch }
+  - { name: route_registrar, release: cf }
   resource_pool: haproxy
   networks:
   - name: default


### PR DESCRIPTION
Rest of the configuration is in secrets