### PR TITLE
Collect container metrics from firehose.

### DIFF
--- a/logsearch-jobs.yml
+++ b/logsearch-jobs.yml
@@ -154,12 +154,13 @@ jobs:
   - {name: ingestor_syslog, release: logsearch}
   - {name: ingestor_cloudfoundry-firehose, release: logsearch-for-cloudfoundry}
   - {name: apply-patch, release: logstash-output-s3-backport}
- 
   resource_pool: ingestor
   networks:
   - name: default
     static_ips: (( static_ips(1) ))
   properties:
+    cloudfoundry:
+      firehose_events: "LogMessage,ContainerMetric,Error"
     logstash_ingestor:
       debug: false
       relp:


### PR DESCRIPTION
Collect additional firehose event types to populate kibana dashboards. This should fix the performance dashboard on logs.fr.cloud.gov that may be relevant to @adborden. Note--there are still more dashboards that we aren't populating--we might just want to capture all firehose events, but I'm not sure which dashboards users want to see.

Here's what we'll get with this change:

<img width="1058" alt="screen shot 2016-11-22 at 12 55 19 am" src="https://cloud.githubusercontent.com/assets/1633460/20512603/6e509808-b04e-11e6-9fd4-4d365e29815c.png">
