### PR TITLE
Drop uaa client errands.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,19 @@
 # 18F cloud.gov ELK deployment
 
 This repo contains the pipeline and [BOSH](https://bosh.io) manifests for deploying cloud.gov [ELK](https://www.elastic.co/videos/introduction-to-the-elk-stack) implementation.
+
+### UAA Setup
+
+To set up the UAA client, add the following to the CF secrets:
+
+```yaml
+properties:
+  uaa:
+    clients:
+      kibana_oauth2_client:
+        secret: CHANGEME
+        scope: scim.userids,cloud_controller.read,openid,oauth.approvals
+        authorized-grant-types: refresh_token,authorization_code
+        redirect-uri: https://CHANGEME/login
+        autoapprove: true
+```

--- a/pipeline.yml
+++ b/pipeline.yml
@@ -133,16 +133,6 @@ jobs:
       <<: *staging-errand-params
       BOSH_ERRAND: upload-kibana-objects
 
-- name: push-uaa-client-staging
-  serial_groups: [bosh-staging]
-  plan:
-  - aggregate: *staging-errand-gets
-  - task: uaa-client-errand
-    file: pipeline-tasks/bosh-errand.yml
-    params:
-      <<: *staging-errand-params
-      BOSH_ERRAND: create-uaa-client
-
 - name: push-event-logger-staging
   plan:
   - aggregate:
@@ -246,16 +236,6 @@ jobs:
     params:
       <<: *production-errand-params
       BOSH_ERRAND: upload-kibana-objects
-
-- name: push-uaa-client-production
-  serial_groups: [bosh-production]
-  plan:
-  - aggregate: *production-errand-gets
-  - task: uaa-client-errand
-    file: pipeline-tasks/bosh-errand.yml
-    params:
-      <<: *production-errand-params
-      BOSH_ERRAND: create-uaa-client
 
 - name: push-event-logger-production
   plan:


### PR DESCRIPTION
Because the cf secrets should be the source of truth for platform clients and users, and because who has time to wait for bosh errands. I added the kibana client to the staging and prod cf secrets.