### PR TITLE
Drop shard allocation errand.

### DIFF
--- a/logsearch-jobs.yml
+++ b/logsearch-jobs.yml
@@ -212,19 +212,6 @@ jobs:
       cluster_monitor:
         backend_servers: (( grab jobs.cluster_monitor.networks.[0].static_ips ))
 
-- name: enable_shard_allocation
-  instances: 1
-  lifecycle: errand
-  templates:
-  - {name: enable_shard_allocation, release: logsearch}
-  resource_pool: errand
-  networks:
-  - name: default
-  properties:
-    enable_shard_allocation:
-      elasticsearch:
-        master_node: (( grab jobs.elasticsearch_master.networks.default.static_ips.[0] ))
-
 - name: smoke-tests
   instances: 1
   resource_pool: errand

--- a/pipeline.yml
+++ b/pipeline.yml
@@ -71,11 +71,6 @@ jobs:
       # - upstream-logsearch-release/*.tgz
       stemcells:
       - logsearch-stemcell/*.tgz
-  - task: enable_shard_allocation
-    file: pipeline-tasks/bosh-errand.yml
-    params:
-      <<: *staging-errand-params
-      BOSH_ERRAND: enable_shard_allocation
   on_failure:
     put: slack
     params: &slack-params
@@ -187,11 +182,6 @@ jobs:
     config: *manifest-config
   - put: logsearch-production-deployment
     params: *deploy-params
-  - task: enable_shard_allocation
-    file: pipeline-tasks/bosh-errand.yml
-    params:
-      <<: *production-errand-params
-      BOSH_ERRAND: enable_shard_allocation
   on_failure:
     put: slack
     params:


### PR DESCRIPTION
No longer needed after merging
https://github.com/cloudfoundry-community/logsearch-boshrelease/pull/19.