### PR TITLE
Configure restart delay allocation.

### DIFF
--- a/logsearch-jobs.yml
+++ b/logsearch-jobs.yml
@@ -293,6 +293,8 @@ properties:
         JAVA_OPTS: '"-Djava.io.tmpdir=${TMP_DIR}"'
     limits:
       fd: 131072  # 2 ** 17
+    recovery:
+      delay_allocation_restart: "15m"
   kibana:
     elasticsearch:
       host: (( grab jobs.elasticsearch_master.networks.default.static_ips.[0] ))


### PR DESCRIPTION
Our stemcell updates take a long time, possibly because all of the compliance jobs we run, so bump the delay interval timeout to 15 minutes. Depends on https://github.com/cloudfoundry-community/logsearch-boshrelease/pull/39; not ready for merge yet.