### PR TITLE
Decrease kibana memory allocation by 10%

### DIFF
--- a/logsearch-jobs.yml
+++ b/logsearch-jobs.yml
@@ -136,6 +136,7 @@ jobs:
     static_ips: (( static_ips(5) ))
   properties:
     kibana:
+      memory_limit: 65
       default_app_id: "dashboard/App-Overview"
       plugins:
       - auth: /var/vcap/packages/kibana-auth-plugin/kibana-auth-plugin.tar.gz


### PR DESCRIPTION
With all the other addons running on our VMs, allocating 75% (the default) of memory to kibana causes the VM to frequently use more than 90% of available memory which triggers alerts.