### PR TITLE
Configure snort addon via linked job.

### DIFF
--- a/logsearch-deployment.yml
+++ b/logsearch-deployment.yml
@@ -15,6 +15,7 @@ releases:
 - {name: logsearch, version: latest}
 - {name: logsearch-for-cloudfoundry, version: latest}
 - {name: riemann, version: latest}
+- {name: snort, version: latest}
 
 resource_pools:
 - name: elasticsearch_master

--- a/logsearch-jobs.yml
+++ b/logsearch-jobs.yml
@@ -8,6 +8,7 @@ jobs:
   - {name: elasticsearch, release: logsearch}
   - {name: riemann-emitter, release: riemann}
   - {name: riemann-checklogs, release: riemann}
+  - {name: snort-config, release: snort}
   resource_pool: elasticsearch_master
   persistent_disk_pool: elasticsearch_master
   networks:


### PR DESCRIPTION
Goes with https://github.com/18F/cg-snort-boshrelease/pull/13.