### PR TITLE
Move cf client IDs into public yml files

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,4 +16,9 @@ properties:
         authorized-grant-types: refresh_token,authorization_code
         redirect-uri: https://CHANGEME/login
         autoapprove: true
+      logsearch_firehose_ingestor:
+        secret: CHANGEME
+        authorized-grant-types: client_credentials
+        authorities: doppler.firehose,cloud_controller.admin
+        override: true
 ```

--- a/logsearch-jobs.yml
+++ b/logsearch-jobs.yml
@@ -261,7 +261,7 @@ instance_groups:
         firehose_events: "LogMessage,ContainerMetric"
         firehose_client_id: logsearch_firehose_ingestor
         skip_ssl_validation: false
-    syslog:
+      syslog:
         host: (( grab instance_groups.ingestor.networks.logsearch.static_ips.[0] ))
         port: 5514
   vm_type: logsearch_ingestor
@@ -328,13 +328,6 @@ instance_groups:
         ingestor:
           backend_servers: (( grab instance_groups.ingestor.networks.logsearch.static_ips ))
         kibana:
-    release: logsearch
-    properties:
-      haproxy:
-        syslog_server: (( grab instance_groups.cluster_monitor.networks.logsearch.static_ips.[0] ))
-        ingestor:
-          backend_servers: (( grab instance_groups.ingestor.networks.logsearch.static_ips ))
-        kibana:
           backend_servers: (( grab instance_groups.kibana.networks.logsearch.static_ips ))
         cluster_monitor:
           backend_servers: (( grab instance_groups.cluster_monitor.networks.logsearch.static_ips ))
@@ -387,3 +380,10 @@ instance_groups:
         port: 9200
       kibana_objects:
         upload_patterns:
+        - {type: index-pattern, pattern: "/var/vcap/jobs/upload-kibana-objects/kibana-objects/index-pattern/*.json"}
+        - {type: config, pattern: "/var/vcap/jobs/upload-kibana-objects/kibana-objects/config/*.json"}
+        - {type: search, pattern: "/var/vcap/jobs/upload-kibana-objects/kibana-objects/search/[app]-*.json"}
+        - {type: visualization, pattern: "/var/vcap/jobs/upload-kibana-objects/kibana-objects/visualization/App-*.json"}
+        - {type: dashboard, pattern: "/var/vcap/jobs/upload-kibana-objects/kibana-objects/dashboard/App-*.json"}
+  networks:
+  - name: logsearch

--- a/logsearch-jobs.yml
+++ b/logsearch-jobs.yml
@@ -219,6 +219,11 @@ instance_groups:
         elasticsearch:
           host: (( grab instance_groups.elasticsearch_master.networks.logsearch.static_ips.[0] ))
           port: 9200
+        env:
+        - KIBANA_OAUTH2_CLIENT_ID: kibana_oauth2_client
+        - SKIP_SSL_VALIDATION: false
+        - CF_SYSTEM_ORG: cloud-gov-operators # Org Managers of this org get admin access
+        - REDIS_HOST: (( grab instance_groups.queue.networks.logsearch.static_ips.[0] ))
   - name: kibana-auth-plugin
     release: logsearch-for-cloudfoundry
   vm_type: logsearch_kibana
@@ -254,7 +259,9 @@ instance_groups:
     properties:
       cloudfoundry:
         firehose_events: "LogMessage,ContainerMetric"
-      syslog:
+        firehose_client_id: logsearch_firehose_ingestor
+        skip_ssl_validation: false
+    syslog:
         host: (( grab instance_groups.ingestor.networks.logsearch.static_ips.[0] ))
         port: 5514
   vm_type: logsearch_ingestor
@@ -321,6 +328,13 @@ instance_groups:
         ingestor:
           backend_servers: (( grab instance_groups.ingestor.networks.logsearch.static_ips ))
         kibana:
+    release: logsearch
+    properties:
+      haproxy:
+        syslog_server: (( grab instance_groups.cluster_monitor.networks.logsearch.static_ips.[0] ))
+        ingestor:
+          backend_servers: (( grab instance_groups.ingestor.networks.logsearch.static_ips ))
+        kibana:
           backend_servers: (( grab instance_groups.kibana.networks.logsearch.static_ips ))
         cluster_monitor:
           backend_servers: (( grab instance_groups.cluster_monitor.networks.logsearch.static_ips ))
@@ -373,10 +387,3 @@ instance_groups:
         port: 9200
       kibana_objects:
         upload_patterns:
-        - {type: index-pattern, pattern: "/var/vcap/jobs/upload-kibana-objects/kibana-objects/index-pattern/*.json"}
-        - {type: config, pattern: "/var/vcap/jobs/upload-kibana-objects/kibana-objects/config/*.json"}
-        - {type: search, pattern: "/var/vcap/jobs/upload-kibana-objects/kibana-objects/search/[app]-*.json"}
-        - {type: visualization, pattern: "/var/vcap/jobs/upload-kibana-objects/kibana-objects/visualization/App-*.json"}
-        - {type: dashboard, pattern: "/var/vcap/jobs/upload-kibana-objects/kibana-objects/dashboard/App-*.json"}
-  networks:
-  - name: logsearch

--- a/logsearch-production.yml
+++ b/logsearch-production.yml
@@ -37,4 +37,4 @@ instance_groups:
     properties:
       kibana:
         env:
-        - CF_API_URI: ci.fr.cloud.gov
+        - CF_API_URI: https://api.fr.cloud.gov

--- a/logsearch-production.yml
+++ b/logsearch-production.yml
@@ -15,6 +15,9 @@ instance_groups:
     static_ips:
     - (( grab terraform_outputs.logsearch_static_ips.[1] ))
     - (( grab terraform_outputs.logsearch_static_ips.[18] ))
+    properties:
+      cloudfoundry:
+        api_endpoint: api.fr.cloud.gov
 
 - name: ls-router
   jobs:
@@ -27,3 +30,11 @@ instance_groups:
           registration_interval: 20s
           uris:
           - logs.fr.cloud.gov
+
+- name: kibana
+  jobs:
+  - name: kibana
+    properties:
+      kibana:
+        env:
+        - CF_API_URI: ci.fr.cloud.gov

--- a/logsearch-staging.yml
+++ b/logsearch-staging.yml
@@ -14,6 +14,9 @@ instance_groups:
   - name: logsearch
     static_ips:
     - (( grab terraform_outputs.logsearch_static_ips.[1] ))
+    properties:
+      cloudfoundry:
+        api_endpoint: api.fr-stage.cloud.gov
 
 - name: ls-router
   jobs:
@@ -26,3 +29,11 @@ instance_groups:
           registration_interval: 20s
           uris:
           - logs.fr-stage.cloud.gov
+
+- name: kibana
+  jobs:
+  - name: kibana
+    properties:
+      kibana:
+        env:
+        - CF_API_URI: ci.fr-stage.cloud.gov

--- a/logsearch-staging.yml
+++ b/logsearch-staging.yml
@@ -36,4 +36,4 @@ instance_groups:
     properties:
       kibana:
         env:
-        - CF_API_URI: ci.fr-stage.cloud.gov
+        - CF_API_URI: https://api.fr-stage.cloud.gov

--- a/secrets.example.yml
+++ b/secrets.example.yml
@@ -7,23 +7,14 @@ instance_groups:
     properties:
       kibana:
         env:
-        - KIBANA_OAUTH2_CLIENT_ID:
         - KIBANA_OAUTH2_CLIENT_SECRET:
-        - SKIP_SSL_VALIDATION: false
-        - CF_API_URI:
-        - CF_SYSTEM_ORG: # Org Managers of this org get admin access
-        - REDIS_HOST: (( grab instance_groups.queue.networks.logsearch.static_ips.[0] ))
-        # - REDIS_HOST: my_redis_host # Redis host to use for sessions
 
 - name: ingestor
   jobs:
   - name: ingestor_cloudfoundry-firehose
     properties:
       cloudfoundry:
-        api_endpoint:
-        firehose_client_id: 
         firehose_client_secret: 
-        skip_ssl_validation: false
 
 - name: ls-router
   jobs:
@@ -47,7 +38,7 @@ instance_groups:
           password:
           port:
           subject:
-          user: 
+          user:
         syslog:
           host: 127.0.0.1
           port: 514 


### PR DESCRIPTION
Move more public information out of secrets and into yml in source control.
This supports updates to runbooks in https://github.com/18F/cg-site/pull/879