### PR TITLE
Restore firehose events on kibana upload.

### DIFF
--- a/logsearch-jobs.yml
+++ b/logsearch-jobs.yml
@@ -378,11 +378,13 @@ instance_groups:
       elasticsearch:
         host: (( grab instance_groups.elasticsearch_master.networks.logsearch.static_ips.[0] ))
         port: 9200
+      cloudfoundry:
+        firehose_events: "LogMessage,ContainerMetric"
       kibana_objects:
         upload_patterns:
         - {type: index-pattern, pattern: "/var/vcap/jobs/upload-kibana-objects/kibana-objects/index-pattern/*.json"}
         - {type: config, pattern: "/var/vcap/jobs/upload-kibana-objects/kibana-objects/config/*.json"}
-        - {type: search, pattern: "/var/vcap/jobs/upload-kibana-objects/kibana-objects/search/[app]-*.json"}
+        - {type: search, pattern: "/var/vcap/jobs/upload-kibana-objects/kibana-objects/search/app-*.json"}
         - {type: visualization, pattern: "/var/vcap/jobs/upload-kibana-objects/kibana-objects/visualization/App-*.json"}
         - {type: dashboard, pattern: "/var/vcap/jobs/upload-kibana-objects/kibana-objects/dashboard/App-*.json"}
   networks:


### PR DESCRIPTION
Tell the `upload-kibana-objects` job that we're collecting `ContainerMetrics`, and hella escape brackets to fix glob matching. We might also want to send a patch upstream to take angle brackets out of the file names.