### PR TITLE
Use multiple kibana instances with health check.

### DIFF
--- a/logsearch-jobs.yml
+++ b/logsearch-jobs.yml
@@ -279,7 +279,7 @@ instance_groups:
         firehose_client_id: logsearch_firehose_ingestor
         skip_ssl_validation: false
       syslog:
-        host: (( grab instance_groups.ingestor.networks.services.static_ips.[0] ))
+        host: 127.0.0.1
         port: 5514
   vm_type: logsearch_ingestor
   stemcell: default

--- a/logsearch-jobs.yml
+++ b/logsearch-jobs.yml
@@ -237,11 +237,12 @@ instance_groups:
       route_registrar:
         routes:
         - name: logsearch
-          registration_interval: 20s
+          registration_interval: 2s
           port: 5601
           health_check:
             name: kibana-up
             script_path: /var/vcap/jobs/kibana/bin/post-start
+          timeout: 1s
   vm_type: logsearch_kibana
   stemcell: default
   azs: [z1]
@@ -329,31 +330,9 @@ instance_groups:
     serial: false # Block to create deploy group 2
     max_in_flight: 4  # Its ok to update multiple parsers at a time
 
-####################################################
-#3nd deploy group - ls-router (haproxy), and errands
-####################################################
-
-- name: ls-router
-  instances: 1
-  jobs:
-  - name: haproxy
-    release: logsearch
-    properties:
-      haproxy:
-        syslog_server: (( grab instance_groups.cluster_monitor.networks.services.static_ips.[0] ))
-        ingestor:
-          backend_servers: (( grab instance_groups.ingestor.networks.services.static_ips ))
-        kibana:
-          backend_servers: (( grab instance_groups.kibana.networks.services.static_ips ))
-        cluster_monitor:
-          backend_servers: (( grab instance_groups.cluster_monitor.networks.services.static_ips ))
-  vm_type: logsearch_haproxy
-  stemcell: default
-  azs: [z1]
-  networks:
-  - name: services
-    static_ips:
-    - (( grab terraform_outputs.logsearch_static_ips.[9] ))
+###########################
+#3nd deploy group - errands
+###########################
 
 - name: smoke-tests
   instances: 1
@@ -371,7 +350,7 @@ instance_groups:
     properties:
       smoke_tests:
         syslog_ingestor:
-          host: (( grab instance_groups.ls-router.networks.services.static_ips.[0] ))
+          host: (( grab instance_groups.ingestor.networks.services.static_ips.[0] ))
         elasticsearch_master:
           host: (( grab instance_groups.elasticsearch_master.networks.services.static_ips.[0] ))
 

--- a/logsearch-jobs.yml
+++ b/logsearch-jobs.yml
@@ -248,8 +248,6 @@ instance_groups:
   azs: [z1]
   networks:
   - name: services
-    static_ips:
-    - (( grab terraform_outputs.logsearch_static_ips.[5] ))
 
 - name: ingestor
   jobs:

--- a/logsearch-jobs.yml
+++ b/logsearch-jobs.yml
@@ -231,6 +231,7 @@ instance_groups:
           client_id: kibana_oauth2_client
           system_org: cloud-gov-operators # Org Managers of this org get admin access
         redis_host: (( grab instance_groups.queue.networks.services.static_ips.[0] ))
+        session_key: (( param "specify kibana session key" ))
   - name: route_registrar
     release: cf
     properties:

--- a/logsearch-jobs.yml
+++ b/logsearch-jobs.yml
@@ -204,7 +204,7 @@ instance_groups:
     max_in_flight: 1 # Only update 1 ES data node at a time or risk downtime
 
 - name: kibana
-  instances: 1
+  instances: 2
   jobs:
   - name: kibana
     release: logsearch
@@ -231,6 +231,17 @@ instance_groups:
           client_id: kibana_oauth2_client
           system_org: cloud-gov-operators # Org Managers of this org get admin access
         redis_host: (( grab instance_groups.queue.networks.services.static_ips.[0] ))
+  - name: route_registrar
+    release: cf
+    properties:
+      route_registrar:
+        routes:
+        - name: logsearch
+          registration_interval: 20s
+          port: 5601
+          health_check:
+            name: kibana-up
+            script_path: /var/vcap/jobs/kibana/bin/post-start
   vm_type: logsearch_kibana
   stemcell: default
   azs: [z1]
@@ -336,8 +347,6 @@ instance_groups:
           backend_servers: (( grab instance_groups.kibana.networks.services.static_ips ))
         cluster_monitor:
           backend_servers: (( grab instance_groups.cluster_monitor.networks.services.static_ips ))
-  - name: route_registrar
-    release: cf
   vm_type: logsearch_haproxy
   stemcell: default
   azs: [z1]

--- a/logsearch-production.yml
+++ b/logsearch-production.yml
@@ -21,18 +21,6 @@ instance_groups:
       cloudfoundry:
         api_endpoint: https://api.fr.cloud.gov
 
-- name: ls-router
-  jobs:
-  - name: route_registrar
-    properties:
-      route_registrar:
-        routes:
-        - name: logsearch
-          port: 80
-          registration_interval: 20s
-          uris:
-          - logs.fr.cloud.gov
-
 - name: kibana
   jobs:
   - name: kibana-auth-plugin
@@ -41,3 +29,9 @@ instance_groups:
         cloudfoundry:
           api_endpoint: https://api.fr.cloud.gov
           system_domain: fr.cloud.gov
+  - name: route_registrar
+    properties:
+      route_registrar:
+        routes:
+        - name: logsearch
+          uris: [logs.fr.cloud.gov]

--- a/logsearch-staging.yml
+++ b/logsearch-staging.yml
@@ -20,18 +20,6 @@ instance_groups:
       cloudfoundry:
         api_endpoint: https://api.fr-stage.cloud.gov
 
-- name: ls-router
-  jobs:
-  - name: route_registrar
-    properties:
-      route_registrar:
-        routes:
-        - name: logsearch 
-          port: 80
-          registration_interval: 20s
-          uris:
-          - logs.fr-stage.cloud.gov
-
 - name: kibana
   jobs:
   - name: kibana-auth-plugin
@@ -40,3 +28,9 @@ instance_groups:
         cloudfoundry:
           api_endpoint: https://api.fr-stage.cloud.gov
           system_domain: fr-stage.cloud.gov
+  - name: route_registrar
+    properties:
+      route_registrar:
+        routes:
+        - name: logsearch
+          uris: [logs.fr-stage.cloud.gov]


### PR DESCRIPTION
AFAICT we can drop ls-router entirely--it's referred to in the smoke tests, but probably not for a good reason. Before I test this on staging, does it look right-ish @cnelson ?