### PR TITLE
Bump releases

### DIFF
--- a/logsearch-development.yml
+++ b/logsearch-development.yml
@@ -10,12 +10,6 @@ instance_groups:
 
 - name: elasticsearch_data
   instances: 3
-  networks:
-  - name: services
-    static_ips:
-    - (( grab terraform_outputs.logsearch_static_ips.[16]))
-    - (( grab terraform_outputs.logsearch_static_ips.[17]))
-    - (( grab terraform_outputs.logsearch_static_ips.[14]))
 
 - name: ingestor
   instances: 1

--- a/logsearch-development.yml
+++ b/logsearch-development.yml
@@ -1,0 +1,45 @@
+instance_groups:
+- name: elasticsearch_master
+  instances: 3
+  networks:
+  - name: services
+    static_ips:
+    - (( grab terraform_outputs.logsearch_static_ips.[0]))
+    - (( grab terraform_outputs.logsearch_static_ips.[4]))
+    - (( grab terraform_outputs.logsearch_static_ips.[6]))
+
+- name: elasticsearch_data
+  instances: 3
+  networks:
+  - name: services
+    static_ips:
+    - (( grab terraform_outputs.logsearch_static_ips.[16]))
+    - (( grab terraform_outputs.logsearch_static_ips.[17]))
+    - (( grab terraform_outputs.logsearch_static_ips.[14]))
+
+- name: ingestor
+  instances: 1
+  networks:
+  - name: services
+    static_ips:
+    - (( grab terraform_outputs.logsearch_static_ips.[18] ))
+  jobs:
+  - name: ingestor_cloudfoundry-firehose
+    properties:
+      cloudfoundry:
+        api_endpoint: https://api.dev.us-gov-west-1.aws-us-gov.cloud.gov
+
+- name: kibana
+  jobs:
+  - name: kibana-auth-plugin
+    properties:
+      kibana-auth:
+        cloudfoundry:
+          api_endpoint: https://api.dev.us-gov-west-1.aws-us-gov.cloud.gov
+          system_domain: dev.us-gov-west-1.aws-us-gov.cloud.gov
+  - name: route_registrar
+    properties:
+      route_registrar:
+        routes:
+        - name: logsearch
+          uris: [logs.dev.us-gov-west-1.aws-us-gov.cloud.gov]

--- a/logsearch-development.yml
+++ b/logsearch-development.yml
@@ -13,10 +13,6 @@ instance_groups:
 
 - name: ingestor
   instances: 1
-  networks:
-  - name: services
-    static_ips:
-    - (( grab terraform_outputs.logsearch_static_ips.[18] ))
   jobs:
   - name: ingestor_cloudfoundry-firehose
     properties:

--- a/logsearch-jobs.yml
+++ b/logsearch-jobs.yml
@@ -193,13 +193,6 @@ instance_groups:
   azs: [z1]
   networks:
   - name: services
-    static_ips:
-    - (( grab terraform_outputs.logsearch_static_ips.[16]))
-    - (( grab terraform_outputs.logsearch_static_ips.[17]))
-    - (( grab terraform_outputs.logsearch_static_ips.[14]))
-    - (( grab terraform_outputs.logsearch_static_ips.[15]))
-    - (( grab terraform_outputs.logsearch_static_ips.[13]))
-    - (( grab terraform_outputs.logsearch_static_ips.[12]))
   update:
     max_in_flight: 1 # Only update 1 ES data node at a time or risk downtime
 

--- a/logsearch-jobs.yml
+++ b/logsearch-jobs.yml
@@ -51,6 +51,7 @@ instance_groups:
   networks:
   - name: services
     static_ips:
+  vm_extensions: [logsearch-lb]
   update:
     max_in_flight: 1 # Should never update more than one ES master node at a time or cluster will go down
 

--- a/logsearch-jobs.yml
+++ b/logsearch-jobs.yml
@@ -1,18 +1,21 @@
 instance_groups:
-###############################################################################
-#First deploy group - elasticsearch_master, cluster_monitor, queue, maintenance
-###############################################################################
+#######################################################
+#First deploy group - elasticsearch_master, maintenance
+#######################################################
 - name: elasticsearch_master
   instances: 1
   jobs:
   - name: elasticsearch
     release: logsearch
+    provides:
+      elasticsearch: {as: elasticsearch_master}
+    consumes:
+      elasticsearch: {from: elasticsearch_master}
     properties:
       elasticsearch:
         node:
           allow_master: true
           allow_data: false
-        master_hosts: (( grab instance_groups.elasticsearch_master.networks.services.static_ips ))
         cluster_name: logsearch
         exec:
           environment:
@@ -40,9 +43,7 @@ instance_groups:
         - 'alert tcp any any -> any 9200 (msg:"Unexpected logsearch action"; content:"POST"; http_method; content: "logs-app"; http_uri; content:"/_update"; http_uri; classtype:web-application-attack; sid:343080002; rev:1;)'
         - 'alert tcp any any -> any 9200 (msg:"Unexpected logsearch action"; content:"POST"; http_method; content: "logs-platform"; http_uri; content:"/_update"; http_uri; classtype:web-application-attack; sid:343080003; rev:1;)'
         - 'alert tcp any any -> any 9200 (msg:"Unexpected logsearch action"; content:"DELETE"; http_method; content: "logs-app"; http_uri; classtype:web-application-attack; sid:343080004; rev:1;)'
-        - (( concat "suppress gen_id 1, sig_id 343080004, track by_src, ip " instance_groups.cluster_monitor.networks.services.static_ips.[0] ))
         - 'alert tcp any any -> any 9200 (msg:"Unexpected logsearch action"; content:"DELETE"; http_method; content: "logs-platform"; http_uri; classtype:web-application-attack; sid:343080005; rev:1;)'
-        - (( concat "suppress gen_id 1, sig_id 343080005, track by_src, ip " instance_groups.cluster_monitor.networks.services.static_ips.[0] ))
   vm_type: logsearch_es_master
   persistent_disk_type: logsearch_es_master
   stemcell: default
@@ -50,97 +51,35 @@ instance_groups:
   networks:
   - name: services
     static_ips:
-    - (( grab terraform_outputs.logsearch_static_ips.[0] ))
   update:
     max_in_flight: 1 # Should never update more than one ES master node at a time or cluster will go down
 
-- name: cluster_monitor
+- name: redis
   instances: 1
   jobs:
-  - release: logsearch
-    name: queue
-    properties:
-      redis:
-        host: 127.0.0.1
-        maxmemory: 10
-  - release: logsearch
-    name: parser
-    properties:
-      redis: (( grab instance_groups.cluster_monitor.jobs.queue.properties.redis ))
-      logstash_parser:
-        filters:
-        - monitor: /var/vcap/packages/logsearch-config/logstash-filters-monitor.conf
-  - release: logsearch
-    name: ingestor_syslog
-    properties:
-      redis: (( grab instance_groups.cluster_monitor.jobs.queue.properties.redis ))
-      logstash_ingestor:
-        syslog:
-          port: 514
-  - release: logsearch
-    name: elasticsearch
-    properties:
-      elasticsearch:
-        master_hosts: [127.0.0.1]
-        cluster_name: monitor
-        node:
-          allow_master: true
-          allow_data: true
-  - release: logsearch
-    name: elasticsearch_config
-    properties:
-      elasticsearch_config:
-        elasticsearch:
-          host: 127.0.0.1
-          port: 9200
-  - release: logsearch
-    name: kibana
-    properties:
-      kibana:
-        port: 5601
-        elasticsearch:
-          host: 127.0.0.1
-          port: 9200
-        memory_limit: 30
-        wait_for_templates: [shards-and-replicas]
-  - release: logsearch
-    name: nats_to_syslog
-  vm_type: logsearch_cluster_monitor
-  persistent_disk_type: logsearch_cluster_monitor
-  stemcell: default
-  azs: [z1]
-  networks:
-  - name: services
-    static_ips:
-    - (( grab terraform_outputs.logsearch_static_ips.[2] ))
-
-- name: queue
-  instances: 1
-  jobs:
-  - {name: queue, release: logsearch}
+  - {name: redis, release: logsearch-for-cloudfoundry}
   vm_type: logsearch_queue
   persistent_disk_type: logsearch_queue
   stemcell: default
   azs: [z1]
   networks:
   - name: services
-    static_ips:
-    - (( grab terraform_outputs.logsearch_static_ips.[3] ))
 
 - name: maintenance
   instances: 1
   jobs:
   - name: curator
     release: logsearch
+    consumes:
+      elasticsearch: {from: elasticsearch_master}
     properties:
       curator:
         purge_logs:
           retention_period: 180
-        elasticsearch:
-          host: (( grab instance_groups.elasticsearch_master.networks.services.static_ips.[0] ))
-          port: 9200
   - name: elasticsearch_config
     release: logsearch
+    consumes:
+      elasticsearch: {from: elasticsearch_master}
     properties:
       elasticsearch_config:
         templates:
@@ -150,8 +89,6 @@ instance_groups:
         - index-mappings-lfc: /var/vcap/jobs/elasticsearch-config-lfc/index-mappings.json
         - index-mappings-app-lfc: /var/vcap/jobs/elasticsearch-config-lfc/index-mappings-app.json
         - index-mappings-platform-lfc: /var/vcap/jobs/elasticsearch-config-lfc/index-mappings-platform.json
-        elasticsearch:
-          host: (( grab instance_groups.elasticsearch_master.networks.services.static_ips.[0] ))
   - name: elasticsearch-config-lfc
     release: logsearch-for-cloudfoundry
   vm_type: logsearch_maintenance
@@ -162,22 +99,21 @@ instance_groups:
   update:
     serial: true # Block on this job to create deploy group 1
 
-##################################################################
-#2nd deploy group - elasticsearch_data, kibana, ingestors, parsers
-##################################################################
-
+#########################################################
+#2nd deploy group - elasticsearch_data, kibana, ingestors
+#########################################################
 - name: elasticsearch_data
   instances: 6
   jobs:
   - name: elasticsearch
     release: logsearch
+    consumes:
+      elasticsearch: {from: elasticsearch_master}
     properties:
       elasticsearch:
         node:
           allow_master: false
           allow_data: true
-        master_hosts: (( grab instance_groups.elasticsearch_master.networks.services.static_ips ))
-        cluster_name: logsearch
         exec:
           environment:
             JAVA_OPTS: '"-Djava.io.tmpdir=${TMP_DIR}"'
@@ -201,6 +137,8 @@ instance_groups:
   jobs:
   - name: kibana
     release: logsearch
+    consumes:
+      elasticsearch: {from: elasticsearch_master}
     properties:
       kibana:
         memory_limit: 65
@@ -209,9 +147,6 @@ instance_groups:
         - auth: /var/vcap/packages/kibana-auth-plugin/kibana-auth-plugin.zip
         config_options: |-
           console.enabled: false
-        elasticsearch:
-          host: (( grab instance_groups.elasticsearch_master.networks.services.static_ips.[0] ))
-          port: 9200
         env:
         - NODE_ENV: production
         source_files: [/var/vcap/jobs/kibana-auth-plugin/config/config.sh]
@@ -223,7 +158,6 @@ instance_groups:
           skip_ssl_validation: false
           client_id: kibana_oauth2_client
           system_org: cloud-gov-operators # Org Managers of this org get admin access
-        redis_host: (( grab instance_groups.queue.networks.services.static_ips.[0] ))
         session_key: (( param "specify kibana session key" ))
   - name: route_registrar
     release: cf
@@ -245,13 +179,15 @@ instance_groups:
 
 - name: ingestor
   jobs:
+  - name: elasticsearch
+    release: logsearch
+    consumes:
+      elasticsearch: {from: elasticsearch_master}
   - name: ingestor_syslog
     release: logsearch
     properties:
       logstash_ingestor:
         outputs:
-        - plugin: redis
-          options: {}
         - plugin: s3
           options:
             region: (( grab terraform_outputs.vpc_region ))
@@ -259,31 +195,6 @@ instance_groups:
             validate_credentials_on_root_bucket: false  # https://github.com/logstash-plugins/logstash-output-s3/issues/132
             server_side_encryption: true
             time_file: 5
-        relp:
-          port: ~
-      redis:
-        host: (( grab instance_groups.queue.networks.services.static_ips.[0] ))
-  - name: ingestor_cloudfoundry-firehose
-    release: logsearch-for-cloudfoundry
-    properties:
-      cloudfoundry:
-        firehose_events: "LogMessage,ContainerMetric"
-        firehose_client_id: logsearch_firehose_ingestor
-        skip_ssl_validation: false
-      syslog:
-        host: 127.0.0.1
-        port: 5514
-  vm_type: logsearch_ingestor
-  stemcell: default
-  azs: [z1]
-  vm_extensions: [logsearch-ingestor-profile]
-
-- name: parser
-  instances: 2
-  jobs:
-  - name: parser
-    release: logsearch
-    properties:
       logstash_parser:
         elasticsearch:
           # Use per-day indexing strategy
@@ -294,38 +205,29 @@ instance_groups:
         deployment_dictionary:
         - /var/vcap/packages/logsearch-config/deployment_lookup.yml
         - /var/vcap/jobs/parser-config-lfc/config/deployment_lookup.yml
-      redis:
-        host: (( grab instance_groups.queue.networks.services.static_ips.[0] ))
-  - name: elasticsearch
-    release: logsearch
+  - name: ingestor_cloudfoundry-firehose
+    release: logsearch-for-cloudfoundry
     properties:
-      elasticsearch:
-        master_hosts: (( grab instance_groups.elasticsearch_master.networks.services.static_ips ))
-        cluster_name: logsearch
-        exec:
-          environment:
-            JAVA_OPTS: '"-Djava.io.tmpdir=${TMP_DIR}"'
-        limits:
-          fd: 131072  # 2 ** 17
-        health:
-          timeout: 900
-        recovery:
-          delay_allocation_restart: "15m"
+      cloudfoundry:
+        firehose_events: "LogMessage,ContainerMetric"
+        firehose_client_id: logsearch_firehose_ingestor
+        skip_ssl_validation: false
+      syslog:
+        host: 127.0.0.1
+        port: 5514
   - name: parser-config-lfc
     release: logsearch-for-cloudfoundry
-  vm_type: logsearch_parser
+  vm_type: logsearch_ingestor
+  persistent_disk_type: logsearch_ingestor
   stemcell: default
   azs: [z1]
   networks:
   - name: services
-  update:
-    serial: false # Block to create deploy group 2
-    max_in_flight: 4  # Its ok to update multiple parsers at a time
+  vm_extensions: [logsearch-ingestor-profile]
 
 ###########################
 #3nd deploy group - errands
 ###########################
-
 - name: smoke-tests
   instances: 1
   vm_type: errand_small
@@ -339,12 +241,8 @@ instance_groups:
   jobs:
   - name: smoke-tests
     release: logsearch
-    properties:
-      smoke_tests:
-        syslog_ingestor:
-          host: (( grab instance_groups.ingestor.networks.services.static_ips.[0] ))
-        elasticsearch_master:
-          host: (( grab instance_groups.elasticsearch_master.networks.services.static_ips.[0] ))
+    consumes:
+      elasticsearch: {from: elasticsearch_master}
 
 - name: upload-kibana-objects
   instances: 1
@@ -359,10 +257,9 @@ instance_groups:
   jobs:
   - name: upload-kibana-objects
     release: logsearch-for-cloudfoundry
+    consumes:
+      elasticsearch: {from: elasticsearch_master}
     properties:
-      elasticsearch:
-        host: (( grab instance_groups.elasticsearch_master.networks.services.static_ips.[0] ))
-        port: 9200
       cloudfoundry:
         firehose_events: "LogMessage,ContainerMetric"
       kibana_objects:
@@ -372,5 +269,3 @@ instance_groups:
         - {type: search, pattern: "/var/vcap/jobs/upload-kibana-objects/kibana-objects/search/app-*.json"}
         - {type: visualization, pattern: "/var/vcap/jobs/upload-kibana-objects/kibana-objects/visualization/App-*.json"}
         - {type: dashboard, pattern: "/var/vcap/jobs/upload-kibana-objects/kibana-objects/dashboard/App-*.json"}
-  networks:
-  - name: services

--- a/logsearch-jobs.yml
+++ b/logsearch-jobs.yml
@@ -209,6 +209,9 @@ instance_groups:
   - name: ingestor_syslog
     release: logsearch
     properties:
+      logstash:
+        queue:
+          max_bytes: 30gb
       logstash_ingestor:
         outputs:
         - plugin: s3

--- a/logsearch-production.yml
+++ b/logsearch-production.yml
@@ -10,11 +10,6 @@ instance_groups:
 
 - name: ingestor
   instances: 2
-  networks:
-  - name: services
-    static_ips:
-    - (( grab terraform_outputs.logsearch_static_ips.[1] ))
-    - (( grab terraform_outputs.logsearch_static_ips.[18] ))
   jobs:
   - name: ingestor_cloudfoundry-firehose
     properties:

--- a/logsearch-production.yml
+++ b/logsearch-production.yml
@@ -9,7 +9,7 @@ instance_groups:
     - (( grab terraform_outputs.logsearch_static_ips.[7] ))
 
 - name: ingestor
-  instances: 2
+  instances: 3
   jobs:
   - name: ingestor_cloudfoundry-firehose
     properties:

--- a/logsearch-staging.yml
+++ b/logsearch-staging.yml
@@ -10,10 +10,6 @@ instance_groups:
 
 - name: ingestor
   instances: 1
-  networks:
-  - name: services
-    static_ips:
-    - (( grab terraform_outputs.logsearch_static_ips.[1] ))
   jobs:
   - name: ingestor_cloudfoundry-firehose
     properties:

--- a/pipeline.yml
+++ b/pipeline.yml
@@ -1,24 +1,27 @@
 ---
 jobs:
-- name: deploy-logsearch-staging
-  serial_groups: [bosh-staging]
+- name: deploy-logsearch-development
+  serial_groups: [bosh-development]
   plan:
   - aggregate:
     - get: common
       resource: master-bosh-root-cert
     - get: pipeline-tasks
     - get: logsearch-config
+      resource: logsearch-config-development
       trigger: true
     - get: common-secrets
-      resource: common-staging
+      resource: common-development
       trigger: true
     - get: logsearch-release
+      resource: logsearch-release-development
     - get: logsearch-for-cloudfoundry-release
+      resource: logsearch-for-cloudfoundry-release-development
     - get: cg-s3-riemann-release
     - get: logsearch-stemcell
       trigger: true
     - get: terraform-yaml
-      resource: terraform-yaml-staging
+      resource: terraform-yaml-development
   - task: logsearch-manifest
     config: &manifest-config
       platform: linux
@@ -40,7 +43,7 @@ jobs:
             logsearch-config/logsearch-deployment.yml \
             logsearch-config/logsearch-jobs.yml \
             common-secrets/secrets.yml \
-            logsearch-config/logsearch-staging.yml \
+            logsearch-config/logsearch-development.yml \
             terraform-yaml/state.yml \
             > logsearch-manifest/manifest.yml
       outputs:
@@ -53,7 +56,7 @@ jobs:
       lint-manifest: logsearch-manifest
     params:
       LINTER_CONFIG: bosh-lint.yml
-  - put: logsearch-staging-deployment
+  - put: logsearch-development-deployment
     params: &deploy-params
       cert: common/master-bosh.crt
       manifest: logsearch-manifest/manifest.yml
@@ -67,11 +70,156 @@ jobs:
     put: slack
     params: &slack-params
       text: |
-        :x: FAILED to deploy logsearch on staging
+        :x: FAILED to deploy logsearch on development
         <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
       channel: {{slack-channel}}
       username: {{slack-username}}
       icon_url: {{slack-icon-url}}
+  on_success:
+    put: slack
+    params:
+      <<: *slack-params
+      text: |
+        :white_check_mark: Successfully deployed logsearch on development
+        <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
+
+- name: smoke-tests-development
+  serial_groups: [bosh-development]
+  plan:
+  - aggregate:
+    - get: common
+      resource: master-bosh-root-cert
+    - get: pipeline-tasks
+    - get: logsearch-development-deployment
+      passed: [deploy-logsearch-development]
+      trigger: true
+    - get: tests-timer
+      trigger: true
+  - task: smoke-tests
+    file: pipeline-tasks/bosh-errand.yml
+    params:
+      BOSH_TARGET: {{logsearch-development-deployment-bosh-target}}
+      BOSH_USERNAME: {{logsearch-development-deployment-bosh-username}}
+      BOSH_PASSWORD: {{logsearch-development-deployment-bosh-password}}
+      BOSH_DEPLOYMENT_NAME: {{logsearch-development-deployment-bosh-deployment}}
+      BOSH_CACERT: common/master-bosh.crt
+      BOSH_ERRAND: smoke-tests
+      BOSH_FLAGS: "--keep-alive"
+  on_failure:
+    put: slack
+    params:
+      <<: *slack-params
+      text: |
+        :x: Smoke tests for logsearch on development FAILED
+        <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
+  on_success:
+    put: slack
+    params:
+      <<: *slack-params
+      channel: {{slack-news-channel}}
+      text: |
+        :white_check_mark: Smoke tests for logsearch on development PASSED
+        <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
+
+- name: smoke-tests-login-development
+  serial_groups: [bosh-development]
+  plan:
+  - aggregate:
+    - get: logsearch-config
+      resource: logsearch-config-development
+    - get: logsearch-development-deployment
+      trigger: true
+    - get: tests-timer
+      trigger: true
+  - task: smoke-tests-login
+    file: logsearch-config/smoke-tests-login.yml
+    params:
+      CF_USERNAME: {{cf-username-development}}
+      CF_PASSWORD: {{cf-password-development}}
+      CF_SYSTEM_DOMAIN: {{cf-system-domain-development}}
+  on_failure:
+    put: slack
+    params:
+      <<: *slack-params
+      text: |
+        :x: Login smoke tests for logsearch on development FAILED
+        <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
+  on_success:
+    put: slack
+    params:
+      <<: *slack-params
+      channel: {{slack-news-channel}}
+      text: |
+        :white_check_mark: Login smoke tests for logsearch on development PASSED
+        <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
+
+- name: upload-kibana-objects-development
+  serial_groups: [bosh-development]
+  plan:
+  - aggregate:
+    - get: common
+      resource: master-bosh-root-cert
+    - get: pipeline-tasks
+    - get: logsearch-development-deployment
+      passed: [deploy-logsearch-development]
+      trigger: true
+  - task: upload-kibana-objects
+    file: pipeline-tasks/bosh-errand.yml
+    params:
+      BOSH_TARGET: {{logsearch-development-deployment-bosh-target}}
+      BOSH_USERNAME: {{logsearch-development-deployment-bosh-username}}
+      BOSH_PASSWORD: {{logsearch-development-deployment-bosh-password}}
+      BOSH_DEPLOYMENT_NAME: {{logsearch-development-deployment-bosh-deployment}}
+      BOSH_CACERT: common/master-bosh.crt
+      BOSH_ERRAND: upload-kibana-objects
+
+- name: deploy-logsearch-staging
+  serial_groups: [bosh-staging]
+  plan:
+  - aggregate:
+    - get: common
+      resource: master-bosh-root-cert
+    - get: pipeline-tasks
+    - get: logsearch-config
+      trigger: true
+    - get: common-secrets
+      resource: common-staging
+      trigger: true
+    - get: logsearch-release
+    - get: logsearch-for-cloudfoundry-release
+    - get: cg-s3-riemann-release
+    - get: logsearch-stemcell
+      trigger: true
+    - get: terraform-yaml
+      resource: terraform-yaml-staging
+  - task: logsearch-manifest
+    config:
+      <<: *manifest-config
+      run:
+        path: sh
+        args:
+        - -exc
+        - |
+          spruce merge \
+            --prune terraform_outputs \
+            logsearch-config/logsearch-deployment.yml \
+            logsearch-config/logsearch-jobs.yml \
+            common-secrets/secrets.yml \
+            logsearch-config/logsearch-staging.yml \
+            terraform-yaml/state.yml \
+            > logsearch-manifest/manifest.yml
+      outputs:
+      - name: logsearch-manifest
+  - *lint-manifest
+  - put: logsearch-staging-deployment
+    params: *deploy-params
+  on_failure:
+    put: slack
+    params:
+      <<: *slack-params
+      text: |
+        :x: FAILED to deploy logsearch on staging
+        <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
   on_success:
     put: slack
     params:
@@ -325,6 +473,16 @@ resources:
     bucket: {{logsearch-private-bucket-production}}
     region_name: {{aws-region}}
     versioned_file: master-bosh.crt
+
+- name: common-development
+  type: cg-common
+  source:
+    bucket_name: {{logsearch-private-bucket-development}}
+    secrets_file: logsearch-development.yml
+    secrets_passphrase: {{logsearch-development-private-passphrase}}
+    bosh_cert: bosh.pem
+    region: {{aws-region}}
+
 - name: common-staging
   type: cg-common
   source:
@@ -343,19 +501,27 @@ resources:
     bosh_cert: bosh.pem
     region: {{aws-region}}
 
-- name: logsearch-release
+- &logsearch-release-tarball
+  name: logsearch-release
   type: s3-iam
   source:
     bucket: {{cg-s3-bosh-releases-bucket}}
     regexp: logsearch-([\d\.]*).tgz
     region_name: {{aws-region}}
 
-- name: logsearch-for-cloudfoundry-release
+- &logsearch-for-cloudfoundry-release-tarball
+  name: logsearch-for-cloudfoundry-release
   type: s3-iam
   source:
     bucket: {{cg-s3-bosh-releases-bucket}}
     regexp: logsearch-for-cloudfoundry-(.*).tgz
     region_name: {{aws-region}}
+
+- <<: *logsearch-release-tarball
+  name: logsearch-release-development
+
+- <<: *logsearch-for-cloudfoundry-release-tarball
+  name: logsearch-for-cloudfoundry-release-development
 
 - name: cg-s3-riemann-release
   type: s3-iam
@@ -370,10 +536,25 @@ resources:
     uri: {{cg-deploy-logsearch-git-url}}
     branch: {{cg-deploy-logsearch-git-branch}}
 
+- name: logsearch-config-development
+  type: git
+  source:
+    uri: {{cg-deploy-logsearch-development-git-url}}
+    branch: {{cg-deploy-logsearch-development-git-branch}}
+
 - name: logsearch-stemcell
   type: bosh-io-stemcell
   source:
     name: bosh-aws-xen-hvm-ubuntu-trusty-go_agent
+
+- name: logsearch-development-deployment
+  type: 18f-bosh-deployment
+  source:
+    target: {{logsearch-development-deployment-bosh-target}}
+    username: {{logsearch-development-deployment-bosh-username}}
+    password: {{logsearch-development-deployment-bosh-password}}
+    deployment: {{logsearch-development-deployment-bosh-deployment}}
+    ignore_ssl: false
 
 - name: logsearch-staging-deployment
   type: 18f-bosh-deployment
@@ -408,6 +589,13 @@ resources:
   type: time
   source:
     interval: 10m
+
+- name: terraform-yaml-development
+  type: s3-iam
+  source:
+    bucket: {{tf-state-bucket-development}}
+    versioned_file: {{tf-state-file-development}}
+    region_name: {{aws-region}}
 
 - name: terraform-yaml-staging
   type: s3-iam

--- a/smoke-tests-login.py
+++ b/smoke-tests-login.py
@@ -1,7 +1,10 @@
 #!/usr/bin/env python
 
 import os
+import logging
 import requests
+
+logging.basicConfig(level=logging.DEBUG)
 
 if __name__ == "__main__":
     session = requests.Session()
@@ -17,8 +20,11 @@ if __name__ == "__main__":
             'username': os.environ['CF_USERNAME'],
             'password': os.environ['CF_PASSWORD'],
             'X-Uaa-Csrf': logs.cookies['X-Uaa-Csrf'],
-        }
+        },
+        # allow_redirects=False,
     )
     print(login.url, login.status_code)
+    # import ipdb
+    # ipdb.set_trace()
     assert login.url == 'https://logs.{}/'.format(os.environ['CF_SYSTEM_DOMAIN'])
     assert login.status_code == 200

--- a/smoke-tests-login.py
+++ b/smoke-tests-login.py
@@ -21,10 +21,7 @@ if __name__ == "__main__":
             'password': os.environ['CF_PASSWORD'],
             'X-Uaa-Csrf': logs.cookies['X-Uaa-Csrf'],
         },
-        # allow_redirects=False,
     )
     print(login.url, login.status_code)
-    # import ipdb
-    # ipdb.set_trace()
     assert login.url == 'https://logs.{}/'.format(os.environ['CF_SYSTEM_DOMAIN'])
     assert login.status_code == 200


### PR DESCRIPTION
* Update templates for latest bosh releases.
* Drop all static IPs except for masters, which other tools depend on.
* Drop cluster monitor.

This is currently deployed to development, where the upgrade Just Worked. I think it would be worth reading up on the logstash persistent queue settings, configured at https://github.com/cloudfoundry-community/logsearch-boshrelease/blob/develop/jobs/ingestor_syslog/spec#L50-L70, before going to production.

To verify: check that development logsearch is receiving logs. Bonus: stop the development masters, wait a while, restart them, and verify that the logs accumulated in the persistent queues eventually reach elasticsearch.

Builds on #82.