### PR TITLE
Maint VM needs a static ip

### DIFF
--- a/logsearch-jobs.yml
+++ b/logsearch-jobs.yml
@@ -159,6 +159,8 @@ instance_groups:
   azs: [z1]
   networks:
   - name: services
+  static_ips:
+    - (( grab terraform_outputs.logsearch_static_ips.[5] ))
   update:
     serial: true # Block on this job to create deploy group 1
 


### PR DESCRIPTION
So that snort can ignore traffic from it