### PR TITLE
Periodically apply slow logs settings to all indices.

### DIFF
--- a/cronjobs/slow-logs.sh
+++ b/cronjobs/slow-logs.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+curl -XPUT ${HOST}:9200/_all/_settings -d @<(cat <<JSON
+{
+  "index.search.slowlog.threshold.query.info": "5s",
+  "index.search.slowlog.threshold.fetch.info": "5s"
+}
+JSON
+)

--- a/logsearch-deployment.yml
+++ b/logsearch-deployment.yml
@@ -21,3 +21,4 @@ releases:
 - {name: cf, version: latest}
 - {name: riemann, version: latest}
 - {name: snort, version: latest}
+- {name: cron, version: latest}

--- a/logsearch-jobs.yml
+++ b/logsearch-jobs.yml
@@ -154,6 +154,23 @@ instance_groups:
           host: (( grab instance_groups.elasticsearch_master.networks.services.static_ips.[0] ))
   - name: elasticsearch-config-lfc
     release: logsearch-for-cloudfoundry
+  # TODO: Drop after https://github.com/cloudfoundry-community/logsearch-for-cloudfoundry/pull/267 is merged
+  - name: cron
+    release: cron
+    properties:
+      cron:
+        entries:
+        - script:
+            name: slow-logs
+            contents: (( file "cronjobs/slow-logs.sh" ))
+          variables:
+            HOST: (( grab instance_groups.elasticsearch_master.networks.services.static_ips.[0] ))
+          minute: "0"
+          hour: "0"
+          day: "*"
+          month: "*"
+          wday: "*"
+          user: root
   vm_type: logsearch_maintenance
   stemcell: default
   azs: [z1]

--- a/pipeline.yml
+++ b/pipeline.yml
@@ -35,7 +35,7 @@ jobs:
         args:
         - -exc
         - |
-          spruce merge \
+          SPRUCE_FILE_BASE_PATH=logsearch-config spruce merge \
             --prune terraform_outputs \
             logsearch-config/logsearch-deployment.yml \
             logsearch-config/logsearch-jobs.yml \
@@ -203,7 +203,7 @@ jobs:
         args:
         - -exc
         - |
-          spruce merge \
+          SPRUCE_FILE_BASE_PATH=logsearch-config spruce merge \
             --prune terraform_outputs \
             logsearch-config/logsearch-deployment.yml \
             logsearch-config/logsearch-jobs.yml \


### PR DESCRIPTION
Temporary solution until https://github.com/cloudfoundry-community/logsearch-for-cloudfoundry/pull/267 is merged.