### PR TITLE
Add platform logsearch.

### DIFF
--- a/logsearch-jobs.yml
+++ b/logsearch-jobs.yml
@@ -11,7 +11,6 @@ instance_groups:
       elasticsearch: {as: elasticsearch_master}
     consumes:
       elasticsearch: {from: elasticsearch_master}
-      syslog_forwarder: nil
     properties:
       elasticsearch:
         node:
@@ -77,13 +76,11 @@ instance_groups:
     release: logsearch
     consumes:
       elasticsearch: {from: elasticsearch_master}
-      syslog_forwarder: nil
   - name: curator
     release: logsearch
     # nil the link and use the colocated instance when https://github.com/cloudfoundry-community/logsearch-boshrelease/pull/90 is merged
     consumes:
       elasticsearch: {from: elasticsearch_master}
-      syslog_forwarder: nil
     properties:
       curator:
         purge_logs:
@@ -92,7 +89,6 @@ instance_groups:
     release: logsearch
     consumes:
       elasticsearch: {from: elasticsearch_master}
-      syslog_forwarder: nil
     properties:
       elasticsearch_config:
         templates:
@@ -141,7 +137,6 @@ instance_groups:
     release: logsearch
     consumes:
       elasticsearch: {from: elasticsearch_master}
-      syslog_forwarder: nil
     properties:
       elasticsearch:
         node:
@@ -172,12 +167,10 @@ instance_groups:
     release: logsearch
     consumes:
       elasticsearch: {from: elasticsearch_master}
-      syslog_forwarder: nil
   - name: kibana
     release: logsearch
     consumes:
       elasticsearch: {from: elasticsearch_master}
-      syslog_forwarder: nil
     properties:
       kibana:
         memory_limit: 65
@@ -222,7 +215,6 @@ instance_groups:
     release: logsearch
     consumes:
       elasticsearch: {from: elasticsearch_master}
-      syslog_forwarder: nil
   - name: archiver_syslog
     release: logsearch
     properties:
@@ -263,7 +255,6 @@ instance_groups:
     release: logsearch
     consumes:
       elasticsearch: {from: elasticsearch_master}
-      syslog_forwarder: nil
   - name: ingestor_syslog
     release: logsearch
     properties:
@@ -318,7 +309,6 @@ instance_groups:
     release: logsearch
     consumes:
       elasticsearch: {from: elasticsearch_master}
-      syslog_forwarder: nil
 
 - name: upload-kibana-objects
   instances: 1
@@ -335,7 +325,6 @@ instance_groups:
     release: logsearch-for-cloudfoundry
     consumes:
       elasticsearch: {from: elasticsearch_master}
-      syslog_forwarder: nil
     properties:
       cloudfoundry:
         firehose_events: "LogMessage,ContainerMetric"

--- a/logsearch-platform-deployment.yml
+++ b/logsearch-platform-deployment.yml
@@ -1,0 +1,21 @@
+director_uuid: (( param "Please set the UUID of your BOSH Director" ))
+
+update:
+  serial: false
+  canaries: 1
+  canary_watch_time: 30000-600000
+  update_watch_time: 5000-600000
+  max_in_flight: 1
+  max_errors: 1
+
+stemcells:
+- alias: default
+  name: bosh-aws-xen-hvm-ubuntu-trusty-go_agent
+  version: latest
+
+name: logsearch-platform
+
+releases:
+- {name: logsearch, version: latest}
+- {name: logsearch-for-cloudfoundry, version: latest}
+- {name: cf, version: latest}

--- a/logsearch-platform-development.yml
+++ b/logsearch-platform-development.yml
@@ -1,24 +1,6 @@
 instance_groups:
-- name: elasticsearch_master
-  instances: 3
-  networks:
-  - name: services
-    static_ips:
-    - (( grab terraform_outputs.logsearch_static_ips.[7]))
-    - (( grab terraform_outputs.logsearch_static_ips.[8]))
-    - (( grab terraform_outputs.logsearch_static_ips.[9]))
-
 - name: elasticsearch_data
   instances: 3
 
 - name: ingestor
   instances: 1
-
-- name: kibana
-  jobs:
-  - name: kibana-auth-plugin
-    properties:
-      kibana-auth:
-        cloudfoundry:
-          api_endpoint: https://api.dev.us-gov-west-1.aws-us-gov.cloud.gov
-          system_domain: dev.us-gov-west-1.aws-us-gov.cloud.gov

--- a/logsearch-platform-development.yml
+++ b/logsearch-platform-development.yml
@@ -1,0 +1,24 @@
+instance_groups:
+- name: elasticsearch_master
+  instances: 3
+  networks:
+  - name: services
+    static_ips:
+    - (( grab terraform_outputs.logsearch_static_ips.[7]))
+    - (( grab terraform_outputs.logsearch_static_ips.[8]))
+    - (( grab terraform_outputs.logsearch_static_ips.[9]))
+
+- name: elasticsearch_data
+  instances: 3
+
+- name: ingestor
+  instances: 1
+
+- name: kibana
+  jobs:
+  - name: kibana-auth-plugin
+    properties:
+      kibana-auth:
+        cloudfoundry:
+          api_endpoint: https://api.dev.us-gov-west-1.aws-us-gov.cloud.gov
+          system_domain: dev.us-gov-west-1.aws-us-gov.cloud.gov

--- a/logsearch-platform-elastalert.yml
+++ b/logsearch-platform-elastalert.yml
@@ -36,7 +36,7 @@ instance_groups:
               - "rev"
               realert:
                 hours: 1
-              alert_subject: "Snort alert on host {0}:{1}:{2}"
+              alert_subject: "Snort alert on host {0}. sid:{1}; rev:{2}"
               alert_subject_args:
               - "@source.host"
               - "sid"

--- a/logsearch-platform-elastalert.yml
+++ b/logsearch-platform-elastalert.yml
@@ -32,18 +32,23 @@ instance_groups:
               index: logs-platform-*
               query_key:
               - "@source.host"
-              - "@message"
+              - "sid"
+              - "rev"
               realert:
                 hours: 1
-              alert_subject: "Snort alert on host {0}"
+              alert_subject: "Snort alert on host {0}:{1}:{2}"
               alert_subject_args:
               - "@source.host"
+              - "sid"
+              - "rev"
               alert_text: "{0}"
               alert_text_args:
               - "@message"
-              pagerduty_incident_key: "snort-alert-{0}"
+              pagerduty_incident_key: "snort-alert-{0}:{1}:{2}"
               pagerduty_incident_key_args:
               - "@source.host"
+              - "sid"
+              - "rev"
               filter:
               - bool:
                   must:

--- a/logsearch-platform-elastalert.yml
+++ b/logsearch-platform-elastalert.yml
@@ -1,0 +1,51 @@
+instance_groups:
+- name: maintenance
+  jobs:
+  - name: elastalert
+    release: elastalert
+    # if niled out, will use the specified elastic host instead, which is our collocated instance
+    # That instance will use disco to find the right master instead of defaulting to a given index
+    consumes:
+      elasticsearch: nil
+    properties:
+      elastalert:
+        elasticsearch:
+          host: 127.0.0.1
+          port: 9200
+        run_every:
+          minutes: 5
+        buffer_time:
+          minutes: 60
+        alert_time_limit:
+          days: 1
+        rules:
+          common:
+            alert:
+            - pagerduty
+            pagerduty_service_key: (( param "set pagerduty service key" ))
+            pagerduty_client_name: elastalert via cg-deploy-logsearch
+          rules:
+          - name: snort
+            content:
+              name: snort-alert
+              type: any
+              index: logs-platform-*
+              query_key:
+              - "@source.host"
+              - "@message"
+              realert:
+                hours: 1
+              alert_subject: "Snort alert on host {0}"
+              alert_subject_args:
+              - "@source.host"
+              alert_text: "{0}"
+              alert_text_args:
+              - "@message"
+              pagerduty_incident_key: "snort-alert-{0}"
+              pagerduty_incident_key_args:
+              - "@source.host"
+              filter:
+              - bool:
+                  must:
+                  - term:
+                      "@source.component": "snort"

--- a/logsearch-platform-jobs.yml
+++ b/logsearch-platform-jobs.yml
@@ -1,0 +1,221 @@
+instance_groups:
+#######################################################
+#First deploy group - elasticsearch_master, maintenance
+#######################################################
+- name: elasticsearch_master
+  instances: 1
+  jobs:
+  - name: elasticsearch
+    release: logsearch
+    provides:
+      elasticsearch: {as: elasticsearch_master}
+    consumes:
+      elasticsearch: {from: elasticsearch_master}
+    properties:
+      elasticsearch:
+        node:
+          allow_master: true
+          allow_data: false
+        cluster_name: logsearch
+        exec:
+          environment:
+            JAVA_OPTS: '"-Djava.io.tmpdir=${TMP_DIR}"'
+        limits:
+          fd: 131072  # 2 ** 17
+        health:
+          timeout: 900
+        recovery:
+          delay_allocation_restart: "15m"
+  vm_type: logsearch_es_master
+  persistent_disk_type: logsearch_es_master
+  stemcell: default
+  azs: [z1]
+  networks:
+  - name: services
+    static_ips:
+  update:
+    max_in_flight: 1 # Should never update more than one ES master node at a time or cluster will go down
+
+- name: redis
+  instances: 1
+  jobs:
+  - {name: redis, release: logsearch-for-cloudfoundry}
+  vm_type: logsearch_queue
+  persistent_disk_type: logsearch_queue
+  stemcell: default
+  azs: [z1]
+  networks:
+  - name: services
+
+- name: maintenance
+  instances: 1
+  jobs:
+  - name: curator
+    release: logsearch
+    consumes:
+      elasticsearch: {from: elasticsearch_master}
+    properties:
+      curator:
+        purge_logs:
+          retention_period: 180
+  - name: elasticsearch_config
+    release: logsearch
+    consumes:
+      elasticsearch: {from: elasticsearch_master}
+    properties:
+      elasticsearch_config:
+        templates:
+        - shards-and-replicas: /var/vcap/jobs/elasticsearch_config/index-templates/shards-and-replicas.json
+        - index-settings: /var/vcap/jobs/elasticsearch_config/index-templates/index-settings.json
+        - index-mappings: /var/vcap/jobs/elasticsearch_config/index-templates/index-mappings.json
+        - index-mappings-lfc: /var/vcap/jobs/elasticsearch-config-lfc/index-mappings.json
+        - index-mappings-app-lfc: /var/vcap/jobs/elasticsearch-config-lfc/index-mappings-app.json
+        - index-mappings-platform-lfc: /var/vcap/jobs/elasticsearch-config-lfc/index-mappings-platform.json
+  - name: elasticsearch-config-lfc
+    release: logsearch-for-cloudfoundry
+
+#########################################################
+#2nd deploy group - elasticsearch_data, kibana, ingestors
+#########################################################
+- name: elasticsearch_data
+  instances: 6
+  jobs:
+  - name: elasticsearch
+    release: logsearch
+    consumes:
+      elasticsearch: {from: elasticsearch_master}
+    properties:
+      elasticsearch:
+        node:
+          allow_master: false
+          allow_data: true
+        exec:
+          environment:
+            JAVA_OPTS: '"-Djava.io.tmpdir=${TMP_DIR}"'
+        limits:
+          fd: 131072  # 2 ** 17
+        health:
+          timeout: 900
+        recovery:
+          delay_allocation_restart: "15m"
+  vm_type: logsearch_es_data
+  persistent_disk_type: logsearch_es_data
+  stemcell: default
+  azs: [z1]
+  networks:
+  - name: services
+  update:
+    max_in_flight: 1 # Only update 1 ES data node at a time or risk downtime
+
+- name: kibana
+  instances: 2
+  jobs:
+  - name: elasticsearch
+    release: logsearch
+    consumes:
+      elasticsearch: {from: elasticsearch_master}
+  - name: kibana
+    release: logsearch
+    consumes:
+      elasticsearch: {from: elasticsearch_master}
+    properties:
+      kibana:
+        memory_limit: 65
+        default_app_id: "dashboard/App-Overview"
+        plugins:
+        - auth: /var/vcap/packages/kibana-auth-plugin/kibana-auth-plugin.zip
+        config_options: |-
+          console.enabled: false
+        env:
+        - NODE_ENV: production
+        source_files: [/var/vcap/jobs/kibana-auth-plugin/config/config.sh]
+  - name: kibana-auth-plugin
+    release: logsearch-for-cloudfoundry
+    properties:
+      kibana-auth:
+        cloudfoundry:
+          skip_ssl_validation: false
+          client_id: kibana_oauth2_client
+          system_org: cloud-gov-operators # Org Managers of this org get admin access
+        session_key: (( param "specify kibana session key" ))
+  vm_type: logsearch_kibana
+  vm_extensions: [platform-kibana-lb]
+  stemcell: default
+  azs: [z1]
+  networks:
+  - name: services
+
+- name: ingestor
+  jobs:
+  - name: elasticsearch
+    release: logsearch
+    consumes:
+      elasticsearch: {from: elasticsearch_master}
+  - name: ingestor_syslog
+    release: logsearch
+    properties:
+      logstash:
+        queue:
+          max_bytes: 30gb
+      logstash_parser:
+        elasticsearch:
+          # Use per-day indexing strategy
+          index: "logs-%{@index_type}-%{+YYYY.MM.dd}"
+          index_type: "%{@type}"
+        filters:
+        - logsearch-for-cf: /var/vcap/packages/logsearch-config-logstash-filters/logstash-filters-default.conf
+        deployment_dictionary:
+        - /var/vcap/packages/logsearch-config/deployment_lookup.yml
+        - /var/vcap/jobs/parser-config-lfc/config/deployment_lookup.yml
+  - name: parser-config-lfc
+    release: logsearch-for-cloudfoundry
+  vm_type: logsearch_ingestor
+  vm_extensions: [platform-syslog-lb]
+  persistent_disk_type: logsearch_ingestor
+  stemcell: default
+  azs: [z1]
+  networks:
+  - name: services
+
+###########################
+#3nd deploy group - errands
+###########################
+- name: smoke-tests
+  instances: 1
+  vm_type: errand_small
+  vm_extensions: [errand-profile]
+  stemcell: default
+  azs: [z1]
+  networks:
+  - name: services
+  lifecycle: errand
+  release: logsearch
+  jobs:
+  - name: smoke-tests
+    release: logsearch
+    consumes:
+      elasticsearch: {from: elasticsearch_master}
+
+- name: upload-kibana-objects
+  instances: 1
+  vm_type: errand_small
+  vm_extensions: [errand-profile]
+  stemcell: default
+  azs: [z1]
+  networks:
+  - name: services
+  lifecycle: errand
+  release: logsearch-for-cloudfoundry
+  jobs:
+  - name: upload-kibana-objects
+    release: logsearch-for-cloudfoundry
+    consumes:
+      elasticsearch: {from: elasticsearch_master}
+    properties:
+      kibana_objects:
+        upload_patterns:
+        - {type: index-pattern, pattern: "/var/vcap/jobs/upload-kibana-objects/kibana-objects/index-pattern/*.json"}
+        - {type: config, pattern: "/var/vcap/jobs/upload-kibana-objects/kibana-objects/config/*.json"}
+        - {type: search, pattern: "/var/vcap/jobs/upload-kibana-objects/kibana-objects/search/platform-*.json"}
+        - {type: visualization, pattern: "/var/vcap/jobs/upload-kibana-objects/kibana-objects/visualization/Platform-*.json"}
+        - {type: dashboard, pattern: "/var/vcap/jobs/upload-kibana-objects/kibana-objects/dashboard/Platform-*.json"}

--- a/logsearch-platform-jobs.yml
+++ b/logsearch-platform-jobs.yml
@@ -110,7 +110,7 @@ instance_groups:
         recovery:
           delay_allocation_restart: "15m"
   vm_type: logsearch_es_data
-  persistent_disk_type: logsearch_es_data
+  persistent_disk_type: logsearch_es_platform_data
   stemcell: default
   azs: [z1]
   networks:

--- a/logsearch-platform-jobs.yml
+++ b/logsearch-platform-jobs.yml
@@ -3,7 +3,7 @@ instance_groups:
 #First deploy group - elasticsearch_master, maintenance
 #######################################################
 - name: elasticsearch_master
-  instances: 1
+  instances: 3
   jobs:
   - name: elasticsearch
     release: logsearch
@@ -33,6 +33,9 @@ instance_groups:
   networks:
   - name: services
     static_ips:
+    - (( grab terraform_outputs.logsearch_static_ips.[7]))
+    - (( grab terraform_outputs.logsearch_static_ips.[8]))
+    - (( grab terraform_outputs.logsearch_static_ips.[9]))
   update:
     max_in_flight: 1 # Should never update more than one ES master node at a time or cluster will go down
 
@@ -119,7 +122,7 @@ instance_groups:
     max_in_flight: 1 # Only update 1 ES data node at a time or risk downtime
 
 - name: kibana
-  instances: 2
+  instances: 0
   jobs:
   - name: elasticsearch
     release: logsearch
@@ -140,15 +143,6 @@ instance_groups:
         env:
         - NODE_ENV: production
         source_files: [/var/vcap/jobs/kibana-auth-plugin/config/config.sh]
-  - name: kibana-auth-plugin
-    release: logsearch-for-cloudfoundry
-    properties:
-      kibana-auth:
-        cloudfoundry:
-          skip_ssl_validation: false
-          client_id: kibana_oauth2_client
-          system_org: cloud-gov-operators # Org Managers of this org get admin access
-        session_key: (( param "specify kibana session key" ))
   vm_type: logsearch_kibana
   vm_extensions: [platform-kibana-lb]
   stemcell: default
@@ -157,6 +151,7 @@ instance_groups:
   - name: services
 
 - name: ingestor
+  instances: 3
   jobs:
   - name: elasticsearch
     release: logsearch

--- a/logsearch-platform-jobs.yml
+++ b/logsearch-platform-jobs.yml
@@ -50,6 +50,10 @@ instance_groups:
 - name: maintenance
   instances: 1
   jobs:
+  - name: elasticsearch
+    release: logsearch
+    consumes:
+      elasticsearch: {from: elasticsearch_master}
   - name: curator
     release: logsearch
     consumes:
@@ -57,7 +61,7 @@ instance_groups:
     properties:
       curator:
         purge_logs:
-          retention_period: 180
+          retention_period: 30
   - name: elasticsearch_config
     release: logsearch
     consumes:

--- a/logsearch-platform-jobs.yml
+++ b/logsearch-platform-jobs.yml
@@ -135,14 +135,9 @@ instance_groups:
     properties:
       kibana:
         memory_limit: 65
-        default_app_id: "dashboard/App-Overview"
-        plugins:
-        - auth: /var/vcap/packages/kibana-auth-plugin/kibana-auth-plugin.zip
-        config_options: |-
-          console.enabled: false
+        default_app_id: "dashboard/Platform-Overview"
         env:
         - NODE_ENV: production
-        source_files: [/var/vcap/jobs/kibana-auth-plugin/config/config.sh]
   vm_type: logsearch_kibana
   vm_extensions: [platform-kibana-lb]
   stemcell: default

--- a/logsearch-platform-jobs.yml
+++ b/logsearch-platform-jobs.yml
@@ -174,7 +174,15 @@ instance_groups:
           index: "logs-%{@index_type}-%{+YYYY.MM.dd}"
           index_type: "%{@type}"
         filters:
-        - logsearch-for-cf: /var/vcap/packages/logsearch-config-logstash-filters/logstash-filters-default.conf
+        - path: /var/vcap/packages/logsearch-config-logstash-filters/logstash-filters-default.conf
+        - content: |
+            if [@source][component] == "snort" {
+              grok {
+                match => {
+                  "@message" => "\[%{INT:gid}:%{INT:sid}:%{INT:rev}\]\s%{DATA:msg}\s\{%{DATA:proto}\}\s%{IP:src_ip}:%{INT:src_port}\s->\s%{IP:dst_ip}:%{INT:dst_port}"
+                }
+              }
+            }
         deployment_dictionary:
         - /var/vcap/packages/logsearch-config/deployment_lookup.yml
         - /var/vcap/jobs/parser-config-lfc/config/deployment_lookup.yml

--- a/pipeline.yml
+++ b/pipeline.yml
@@ -1,6 +1,6 @@
 ---
 jobs:
-- name: deploy-logsearch-development
+- name: deploy-logsearch-platform-development
   serial_groups: [bosh-development]
   plan:
   - aggregate:
@@ -40,10 +40,10 @@ jobs:
         - |
           SPRUCE_FILE_BASE_PATH=logsearch-config spruce merge \
             --prune terraform_outputs \
-            logsearch-config/logsearch-deployment.yml \
-            logsearch-config/logsearch-jobs.yml \
+            logsearch-config/logsearch-platform-deployment.yml \
+            logsearch-config/logsearch-platform-jobs.yml \
             common-secrets/secrets.yml \
-            logsearch-config/logsearch-development.yml \
+            logsearch-config/logsearch-platform-development.yml \
             terraform-yaml/state.yml \
             > logsearch-manifest/manifest.yml
       outputs:
@@ -56,6 +56,164 @@ jobs:
       lint-manifest: logsearch-manifest
     params:
       LINTER_CONFIG: bosh-lint.yml
+  - put: logsearch-platform-development-deployment
+    params: &deploy-params
+      cert: common/master-bosh.crt
+      manifest: logsearch-manifest/manifest.yml
+      releases:
+      - logsearch-release/*.tgz
+      - logsearch-for-cloudfoundry-release/*.tgz
+      - cg-s3-riemann-release/*.tgz
+      stemcells:
+      - logsearch-stemcell/*.tgz
+  on_failure:
+    put: slack
+    params: &slack-params
+      text: |
+        :x: FAILED to deploy platform logsearch on development
+        <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
+      channel: {{slack-channel}}
+      username: {{slack-username}}
+      icon_url: {{slack-icon-url}}
+  on_success:
+    put: slack
+    params:
+      <<: *slack-params
+      text: |
+        :white_check_mark: Successfully deployed platform logsearch on development
+        <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
+
+- name: smoke-tests-platform-development
+  serial_groups: [bosh-development]
+  plan:
+  - aggregate:
+    - get: common
+      resource: master-bosh-root-cert
+    - get: pipeline-tasks
+    - get: logsearch-platform-development-deployment
+      passed: [deploy-logsearch-platform-development]
+      trigger: true
+    - get: tests-timer
+      trigger: true
+  - task: smoke-tests
+    file: pipeline-tasks/bosh-errand.yml
+    params:
+      BOSH_TARGET: {{logsearch-development-deployment-bosh-target}}
+      BOSH_USERNAME: {{logsearch-development-deployment-bosh-username}}
+      BOSH_PASSWORD: {{logsearch-development-deployment-bosh-password}}
+      BOSH_DEPLOYMENT_NAME: {{logsearch-development-deployment-bosh-deployment}}
+      BOSH_CACERT: common/master-bosh.crt
+      BOSH_ERRAND: smoke-tests
+      BOSH_FLAGS: "--keep-alive"
+  on_failure:
+    put: slack
+    params:
+      <<: *slack-params
+      text: |
+        :x: Smoke tests for platform logsearch on development FAILED
+        <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
+  on_success:
+    put: slack
+    params:
+      <<: *slack-params
+      channel: {{slack-news-channel}}
+      text: |
+        :white_check_mark: Smoke tests for platform logsearch on development PASSED
+        <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
+
+- name: smoke-tests-login-platform-development
+  serial_groups: [bosh-platform-development]
+  plan:
+  - aggregate:
+    - get: logsearch-config
+      resource: logsearch-config-development
+    - get: logsearch-development-deployment
+      trigger: true
+    - get: tests-timer
+      trigger: true
+  - task: smoke-tests-login
+    file: logsearch-config/smoke-tests-login.yml
+    params:
+      CF_USERNAME: {{cf-username-development}}
+      CF_PASSWORD: {{cf-password-development}}
+      CF_SYSTEM_DOMAIN: {{cf-system-domain-development}}
+  on_failure:
+    put: slack
+    params:
+      <<: *slack-params
+      text: |
+        :x: Login smoke tests for platform logsearch on development FAILED
+        <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
+  on_success:
+    put: slack
+    params:
+      <<: *slack-params
+      channel: {{slack-news-channel}}
+      text: |
+        :white_check_mark: Login smoke tests for platform logsearch on development PASSED
+        <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
+
+- name: upload-kibana-objects-platform-development
+  serial_groups: [bosh-platform-development]
+  plan:
+  - aggregate:
+    - get: common
+      resource: master-bosh-root-cert
+    - get: pipeline-tasks
+    - get: logsearch-platform-development-deployment
+      passed: [deploy-logsearch-platform-development]
+      trigger: true
+  - task: upload-kibana-objects
+    file: pipeline-tasks/bosh-errand.yml
+    params:
+      BOSH_TARGET: {{logsearch-development-deployment-bosh-target}}
+      BOSH_USERNAME: {{logsearch-development-deployment-bosh-username}}
+      BOSH_PASSWORD: {{logsearch-development-deployment-bosh-password}}
+      BOSH_DEPLOYMENT_NAME: {{logsearch-development-deployment-bosh-deployment}}
+      BOSH_CACERT: common/master-bosh.crt
+      BOSH_ERRAND: upload-kibana-objects
+
+- name: deploy-logsearch-development
+  serial_groups: [bosh-development]
+  plan:
+  - aggregate:
+    - get: common
+      resource: master-bosh-root-cert
+    - get: pipeline-tasks
+    - get: logsearch-config
+      resource: logsearch-config-development
+      trigger: true
+    - get: common-secrets
+      resource: common-development
+      trigger: true
+    - get: logsearch-release
+      resource: logsearch-release-development
+    - get: logsearch-for-cloudfoundry-release
+      resource: logsearch-for-cloudfoundry-release-development
+    - get: cg-s3-riemann-release
+    - get: logsearch-stemcell
+      trigger: true
+    - get: terraform-yaml
+      resource: terraform-yaml-development
+  - task: logsearch-manifest
+    config:
+      <<: *manifest-config
+      run:
+        path: sh
+        args:
+        - -exc
+        - |
+          SPRUCE_FILE_BASE_PATH=logsearch-config spruce merge \
+            --prune terraform_outputs \
+            logsearch-config/logsearch-deployment.yml \
+            logsearch-config/logsearch-jobs.yml \
+            common-secrets/secrets.yml \
+            logsearch-config/logsearch-development.yml \
+            terraform-yaml/state.yml \
+            > logsearch-manifest/manifest.yml
+      outputs:
+      - name: logsearch-manifest
+  - *lint-manifest
   - put: logsearch-development-deployment
     params: &deploy-params
       cert: common/master-bosh.crt
@@ -549,30 +707,45 @@ resources:
 
 - name: logsearch-development-deployment
   type: 18f-bosh-deployment
-  source:
+  source: &bosh-params-development
     target: {{logsearch-development-deployment-bosh-target}}
     username: {{logsearch-development-deployment-bosh-username}}
     password: {{logsearch-development-deployment-bosh-password}}
-    deployment: {{logsearch-development-deployment-bosh-deployment}}
-    ignore_ssl: false
+    deployment: logsearch
 
 - name: logsearch-staging-deployment
   type: 18f-bosh-deployment
-  source:
+  source: &bosh-params-staging
     target: {{logsearch-staging-deployment-bosh-target}}
     username: {{logsearch-staging-deployment-bosh-username}}
     password: {{logsearch-staging-deployment-bosh-password}}
-    deployment: {{logsearch-staging-deployment-bosh-deployment}}
-    ignore_ssl: false
+    deployment: logsearch
 
 - name: logsearch-production-deployment
   type: 18f-bosh-deployment
-  source:
+  source: &bosh-params-production
     target: {{logsearch-production-deployment-bosh-target}}
     username: {{logsearch-production-deployment-bosh-username}}
     password: {{logsearch-production-deployment-bosh-password}}
-    deployment: {{logsearch-production-deployment-bosh-deployment}}
-    ignore_ssl: false
+    deployment: logsearch
+
+- name: logsearch-platform-development-deployment
+  type: 18f-bosh-deployment
+  source:
+    <<: *bosh-params-development
+    deployment: logsearch-platform
+
+# - name: logsearch-platform-staging-deployment
+#   type: 18f-bosh-deployment
+#   source:
+#     <<: *bosh-params-staging
+#     deployment: logsearch-platform
+
+# - name: logsearch-platform-production-deployment
+#   type: 18f-bosh-deployment
+#   source:
+#     <<: *bosh-params-production
+#     deployment: logsearch-platform
 
 - name: pipeline-tasks
   type: git

--- a/pipeline.yml
+++ b/pipeline.yml
@@ -123,57 +123,57 @@ jobs:
         :white_check_mark: Smoke tests for platform logsearch on development PASSED
         <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
 
-- name: smoke-tests-login-platform-development
-  serial_groups: [bosh-platform-development]
-  plan:
-  - aggregate:
-    - get: logsearch-config
-      resource: logsearch-config-development
-    - get: logsearch-development-deployment
-      trigger: true
-    - get: tests-timer
-      trigger: true
-  - task: smoke-tests-login
-    file: logsearch-config/smoke-tests-login.yml
-    params:
-      CF_USERNAME: {{cf-username-development}}
-      CF_PASSWORD: {{cf-password-development}}
-      CF_SYSTEM_DOMAIN: {{cf-system-domain-development}}
-  on_failure:
-    put: slack
-    params:
-      <<: *slack-params
-      text: |
-        :x: Login smoke tests for platform logsearch on development FAILED
-        <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
-  on_success:
-    put: slack
-    params:
-      <<: *slack-params
-      channel: {{slack-news-channel}}
-      text: |
-        :white_check_mark: Login smoke tests for platform logsearch on development PASSED
-        <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
+# - name: smoke-tests-login-platform-development
+#   serial_groups: [bosh-platform-development]
+#   plan:
+#   - aggregate:
+#     - get: logsearch-config
+#       resource: logsearch-config-development
+#     - get: logsearch-development-deployment
+#       trigger: true
+#     - get: tests-timer
+#       trigger: true
+#   - task: smoke-tests-login
+#     file: logsearch-config/smoke-tests-login.yml
+#     params:
+#       CF_USERNAME: {{cf-username-development}}
+#       CF_PASSWORD: {{cf-password-development}}
+#       CF_SYSTEM_DOMAIN: {{cf-system-domain-development}}
+#   on_failure:
+#     put: slack
+#     params:
+#       <<: *slack-params
+#       text: |
+#         :x: Login smoke tests for platform logsearch on development FAILED
+#         <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
+#   on_success:
+#     put: slack
+#     params:
+#       <<: *slack-params
+#       channel: {{slack-news-channel}}
+#       text: |
+#         :white_check_mark: Login smoke tests for platform logsearch on development PASSED
+#         <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
 
-- name: upload-kibana-objects-platform-development
-  serial_groups: [bosh-platform-development]
-  plan:
-  - aggregate:
-    - get: common
-      resource: master-bosh-root-cert
-    - get: pipeline-tasks
-    - get: logsearch-platform-development-deployment
-      passed: [deploy-logsearch-platform-development]
-      trigger: true
-  - task: upload-kibana-objects
-    file: pipeline-tasks/bosh-errand.yml
-    params:
-      BOSH_TARGET: {{logsearch-development-deployment-bosh-target}}
-      BOSH_USERNAME: {{logsearch-development-deployment-bosh-username}}
-      BOSH_PASSWORD: {{logsearch-development-deployment-bosh-password}}
-      BOSH_DEPLOYMENT_NAME: logsearch-platform
-      BOSH_CACERT: common/master-bosh.crt
-      BOSH_ERRAND: upload-kibana-objects
+# - name: upload-kibana-objects-platform-development
+#   serial_groups: [bosh-platform-development]
+#   plan:
+#   - aggregate:
+#     - get: common
+#       resource: master-bosh-root-cert
+#     - get: pipeline-tasks
+#     - get: logsearch-platform-development-deployment
+#       passed: [deploy-logsearch-platform-development]
+#       trigger: true
+#   - task: upload-kibana-objects
+#     file: pipeline-tasks/bosh-errand.yml
+#     params:
+#       BOSH_TARGET: {{logsearch-development-deployment-bosh-target}}
+#       BOSH_USERNAME: {{logsearch-development-deployment-bosh-username}}
+#       BOSH_PASSWORD: {{logsearch-development-deployment-bosh-password}}
+#       BOSH_DEPLOYMENT_NAME: logsearch-platform
+#       BOSH_CACERT: common/master-bosh.crt
+#       BOSH_ERRAND: upload-kibana-objects
 
 - name: deploy-logsearch-platform-staging
   serial_groups: [bosh-platform-staging]
@@ -208,7 +208,6 @@ jobs:
             logsearch-config/logsearch-platform-jobs.yml \
             logsearch-config/logsearch-platform-elastalert.yml \
             common-secrets/secrets.yml \
-            logsearch-config/logsearch-platform-staging.yml \
             terraform-yaml/state.yml \
             > logsearch-manifest/manifest.yml
       outputs:
@@ -277,56 +276,56 @@ jobs:
         :white_check_mark: Smoke tests for platform logsearch on staging PASSED
         <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
 
-- name: smoke-tests-login-platform-staging
-  serial_groups: [bosh-platform-staging]
-  plan:
-  - aggregate:
-    - get: logsearch-config
-    - get: logsearch-staging-deployment
-      trigger: true
-    - get: tests-timer
-      trigger: true
-  - task: smoke-tests-login
-    file: logsearch-config/smoke-tests-login.yml
-    params:
-      CF_USERNAME: {{cf-username-staging}}
-      CF_PASSWORD: {{cf-password-staging}}
-      CF_SYSTEM_DOMAIN: {{cf-system-domain-staging}}
-  on_failure:
-    put: slack
-    params:
-      <<: *slack-params
-      text: |
-        :x: Login smoke tests for platform logsearch on staging FAILED
-        <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
-  on_success:
-    put: slack
-    params:
-      <<: *slack-params
-      channel: {{slack-news-channel}}
-      text: |
-        :white_check_mark: Login smoke tests for platform logsearch on staging PASSED
-        <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
+# - name: smoke-tests-login-platform-staging
+#   serial_groups: [bosh-platform-staging]
+#   plan:
+#   - aggregate:
+#     - get: logsearch-config
+#     - get: logsearch-staging-deployment
+#       trigger: true
+#     - get: tests-timer
+#       trigger: true
+#   - task: smoke-tests-login
+#     file: logsearch-config/smoke-tests-login.yml
+#     params:
+#       CF_USERNAME: {{cf-username-staging}}
+#       CF_PASSWORD: {{cf-password-staging}}
+#       CF_SYSTEM_DOMAIN: {{cf-system-domain-staging}}
+#   on_failure:
+#     put: slack
+#     params:
+#       <<: *slack-params
+#       text: |
+#         :x: Login smoke tests for platform logsearch on staging FAILED
+#         <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
+#   on_success:
+#     put: slack
+#     params:
+#       <<: *slack-params
+#       channel: {{slack-news-channel}}
+#       text: |
+#         :white_check_mark: Login smoke tests for platform logsearch on staging PASSED
+#         <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
 
-- name: upload-kibana-objects-platform-staging
-  serial_groups: [bosh-platform-staging]
-  plan:
-  - aggregate:
-    - get: common
-      resource: master-bosh-root-cert
-    - get: pipeline-tasks
-    - get: logsearch-platform-staging-deployment
-      passed: [deploy-logsearch-platform-staging]
-      trigger: true
-  - task: upload-kibana-objects
-    file: pipeline-tasks/bosh-errand.yml
-    params:
-      BOSH_TARGET: {{logsearch-staging-deployment-bosh-target}}
-      BOSH_USERNAME: {{logsearch-staging-deployment-bosh-username}}
-      BOSH_PASSWORD: {{logsearch-staging-deployment-bosh-password}}
-      BOSH_DEPLOYMENT_NAME: logsearch-platform
-      BOSH_CACERT: common/master-bosh.crt
-      BOSH_ERRAND: upload-kibana-objects
+# - name: upload-kibana-objects-platform-staging
+#   serial_groups: [bosh-platform-staging]
+#   plan:
+#   - aggregate:
+#     - get: common
+#       resource: master-bosh-root-cert
+#     - get: pipeline-tasks
+#     - get: logsearch-platform-staging-deployment
+#       passed: [deploy-logsearch-platform-staging]
+#       trigger: true
+#   - task: upload-kibana-objects
+#     file: pipeline-tasks/bosh-errand.yml
+#     params:
+#       BOSH_TARGET: {{logsearch-staging-deployment-bosh-target}}
+#       BOSH_USERNAME: {{logsearch-staging-deployment-bosh-username}}
+#       BOSH_PASSWORD: {{logsearch-staging-deployment-bosh-password}}
+#       BOSH_DEPLOYMENT_NAME: logsearch-platform
+#       BOSH_CACERT: common/master-bosh.crt
+#       BOSH_ERRAND: upload-kibana-objects
 
 - name: deploy-logsearch-platform-production
   serial_groups: [bosh-platform-production]
@@ -361,7 +360,6 @@ jobs:
             logsearch-config/logsearch-platform-jobs.yml \
             logsearch-config/logsearch-platform-elastalert.yml \
             common-secrets/secrets.yml \
-            logsearch-config/logsearch-platform-production.yml \
             terraform-yaml/state.yml \
             > logsearch-manifest/manifest.yml
       outputs:
@@ -430,56 +428,56 @@ jobs:
         :white_check_mark: Smoke tests for platform logsearch on production PASSED
         <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
 
-- name: smoke-tests-login-platform-production
-  serial_groups: [bosh-platform-production]
-  plan:
-  - aggregate:
-    - get: logsearch-config
-    - get: logsearch-production-deployment
-      trigger: true
-    - get: tests-timer
-      trigger: true
-  - task: smoke-tests-login
-    file: logsearch-config/smoke-tests-login.yml
-    params:
-      CF_USERNAME: {{cf-username-production}}
-      CF_PASSWORD: {{cf-password-production}}
-      CF_SYSTEM_DOMAIN: {{cf-system-domain-production}}
-  on_failure:
-    put: slack
-    params:
-      <<: *slack-params
-      text: |
-        :x: Login smoke tests for platform logsearch on production FAILED
-        <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
-  on_success:
-    put: slack
-    params:
-      <<: *slack-params
-      channel: {{slack-news-channel}}
-      text: |
-        :white_check_mark: Login smoke tests for platform logsearch on production PASSED
-        <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
+# - name: smoke-tests-login-platform-production
+#   serial_groups: [bosh-platform-production]
+#   plan:
+#   - aggregate:
+#     - get: logsearch-config
+#     - get: logsearch-production-deployment
+#       trigger: true
+#     - get: tests-timer
+#       trigger: true
+#   - task: smoke-tests-login
+#     file: logsearch-config/smoke-tests-login.yml
+#     params:
+#       CF_USERNAME: {{cf-username-production}}
+#       CF_PASSWORD: {{cf-password-production}}
+#       CF_SYSTEM_DOMAIN: {{cf-system-domain-production}}
+#   on_failure:
+#     put: slack
+#     params:
+#       <<: *slack-params
+#       text: |
+#         :x: Login smoke tests for platform logsearch on production FAILED
+#         <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
+#   on_success:
+#     put: slack
+#     params:
+#       <<: *slack-params
+#       channel: {{slack-news-channel}}
+#       text: |
+#         :white_check_mark: Login smoke tests for platform logsearch on production PASSED
+#         <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
 
-- name: upload-kibana-objects-platform-production
-  serial_groups: [bosh-platform-production]
-  plan:
-  - aggregate:
-    - get: common
-      resource: master-bosh-root-cert
-    - get: pipeline-tasks
-    - get: logsearch-platform-production-deployment
-      passed: [deploy-logsearch-platform-production]
-      trigger: true
-  - task: upload-kibana-objects
-    file: pipeline-tasks/bosh-errand.yml
-    params:
-      BOSH_TARGET: {{logsearch-production-deployment-bosh-target}}
-      BOSH_USERNAME: {{logsearch-production-deployment-bosh-username}}
-      BOSH_PASSWORD: {{logsearch-production-deployment-bosh-password}}
-      BOSH_DEPLOYMENT_NAME: logsearch-platform
-      BOSH_CACERT: common/master-bosh.crt
-      BOSH_ERRAND: upload-kibana-objects
+# - name: upload-kibana-objects-platform-production
+#   serial_groups: [bosh-platform-production]
+#   plan:
+#   - aggregate:
+#     - get: common
+#       resource: master-bosh-root-cert
+#     - get: pipeline-tasks
+#     - get: logsearch-platform-production-deployment
+#       passed: [deploy-logsearch-platform-production]
+#       trigger: true
+#   - task: upload-kibana-objects
+#     file: pipeline-tasks/bosh-errand.yml
+#     params:
+#       BOSH_TARGET: {{logsearch-production-deployment-bosh-target}}
+#       BOSH_USERNAME: {{logsearch-production-deployment-bosh-username}}
+#       BOSH_PASSWORD: {{logsearch-production-deployment-bosh-password}}
+#       BOSH_DEPLOYMENT_NAME: logsearch-platform
+#       BOSH_CACERT: common/master-bosh.crt
+#       BOSH_ERRAND: upload-kibana-objects
 
 - name: deploy-logsearch-development
   serial_groups: [bosh-development]

--- a/pipeline.yml
+++ b/pipeline.yml
@@ -175,6 +175,312 @@ jobs:
       BOSH_CACERT: common/master-bosh.crt
       BOSH_ERRAND: upload-kibana-objects
 
+- name: deploy-logsearch-platform-staging
+  serial_groups: [bosh-platform-staging]
+  plan:
+  - aggregate:
+    - get: common
+      resource: master-bosh-root-cert
+    - get: pipeline-tasks
+    - get: logsearch-config
+      trigger: true
+    - get: common-secrets
+      resource: common-platform-staging
+      trigger: true
+    - get: logsearch-release
+    - get: logsearch-for-cloudfoundry-release
+    - get: elastalert-release
+    - get: logsearch-stemcell
+      trigger: true
+    - get: terraform-yaml
+      resource: terraform-yaml-staging
+  - task: logsearch-manifest
+    config:
+      <<: *manifest-config
+      run:
+        path: sh
+        args:
+        - -exc
+        - |
+          SPRUCE_FILE_BASE_PATH=logsearch-config spruce merge \
+            --prune terraform_outputs \
+            logsearch-config/logsearch-platform-deployment.yml \
+            logsearch-config/logsearch-platform-jobs.yml \
+            logsearch-config/logsearch-platform-elastalert.yml \
+            common-secrets/secrets.yml \
+            logsearch-config/logsearch-platform-staging.yml \
+            terraform-yaml/state.yml \
+            > logsearch-manifest/manifest.yml
+      outputs:
+      - name: logsearch-manifest
+  - *lint-manifest
+  - put: logsearch-platform-staging-deployment
+    params: &deploy-params-platform
+      cert: common/master-bosh.crt
+      manifest: logsearch-manifest/manifest.yml
+      releases:
+      - logsearch-release/*.tgz
+      - logsearch-for-cloudfoundry-release/*.tgz
+      - elastalert-release/*.tgz
+      stemcells:
+      - logsearch-stemcell/*.tgz
+  on_failure:
+    put: slack
+    params:
+      <<: *slack-params
+      text: |
+        :x: FAILED to deploy platform logsearch on staging
+        <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
+  on_success:
+    put: slack
+    params:
+      <<: *slack-params
+      text: |
+        :white_check_mark: Successfully deployed platform logsearch on staging
+        <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
+
+- name: smoke-tests-platform-staging
+  serial_groups: [bosh-platform-staging]
+  plan:
+  - aggregate:
+    - get: common
+      resource: master-bosh-root-cert
+    - get: pipeline-tasks
+    - get: logsearch-platform-staging-deployment
+      passed: [deploy-logsearch-platform-staging]
+      trigger: true
+    - get: tests-timer
+      trigger: true
+  - task: smoke-tests
+    file: pipeline-tasks/bosh-errand.yml
+    params:
+      BOSH_TARGET: {{logsearch-staging-deployment-bosh-target}}
+      BOSH_USERNAME: {{logsearch-staging-deployment-bosh-username}}
+      BOSH_PASSWORD: {{logsearch-staging-deployment-bosh-password}}
+      BOSH_DEPLOYMENT_NAME: logsearch-platform
+      BOSH_CACERT: common/master-bosh.crt
+      BOSH_ERRAND: smoke-tests
+      BOSH_FLAGS: "--keep-alive"
+  on_failure:
+    put: slack
+    params:
+      <<: *slack-params
+      text: |
+        :x: Smoke tests for platform logsearch on staging FAILED
+        <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
+  on_success:
+    put: slack
+    params:
+      <<: *slack-params
+      channel: {{slack-news-channel}}
+      text: |
+        :white_check_mark: Smoke tests for platform logsearch on staging PASSED
+        <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
+
+- name: smoke-tests-login-platform-staging
+  serial_groups: [bosh-platform-staging]
+  plan:
+  - aggregate:
+    - get: logsearch-config
+    - get: logsearch-staging-deployment
+      trigger: true
+    - get: tests-timer
+      trigger: true
+  - task: smoke-tests-login
+    file: logsearch-config/smoke-tests-login.yml
+    params:
+      CF_USERNAME: {{cf-username-staging}}
+      CF_PASSWORD: {{cf-password-staging}}
+      CF_SYSTEM_DOMAIN: {{cf-system-domain-staging}}
+  on_failure:
+    put: slack
+    params:
+      <<: *slack-params
+      text: |
+        :x: Login smoke tests for platform logsearch on staging FAILED
+        <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
+  on_success:
+    put: slack
+    params:
+      <<: *slack-params
+      channel: {{slack-news-channel}}
+      text: |
+        :white_check_mark: Login smoke tests for platform logsearch on staging PASSED
+        <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
+
+- name: upload-kibana-objects-platform-staging
+  serial_groups: [bosh-platform-staging]
+  plan:
+  - aggregate:
+    - get: common
+      resource: master-bosh-root-cert
+    - get: pipeline-tasks
+    - get: logsearch-platform-staging-deployment
+      passed: [deploy-logsearch-platform-staging]
+      trigger: true
+  - task: upload-kibana-objects
+    file: pipeline-tasks/bosh-errand.yml
+    params:
+      BOSH_TARGET: {{logsearch-staging-deployment-bosh-target}}
+      BOSH_USERNAME: {{logsearch-staging-deployment-bosh-username}}
+      BOSH_PASSWORD: {{logsearch-staging-deployment-bosh-password}}
+      BOSH_DEPLOYMENT_NAME: logsearch-platform
+      BOSH_CACERT: common/master-bosh.crt
+      BOSH_ERRAND: upload-kibana-objects
+
+- name: deploy-logsearch-platform-production
+  serial_groups: [bosh-platform-production]
+  plan:
+  - aggregate:
+    - get: common
+      resource: master-bosh-root-cert
+    - get: pipeline-tasks
+    - get: logsearch-config
+      trigger: true
+    - get: common-secrets
+      resource: common-platform-production
+      trigger: true
+    - get: logsearch-release
+    - get: logsearch-for-cloudfoundry-release
+    - get: elastalert-release
+    - get: logsearch-stemcell
+      trigger: true
+    - get: terraform-yaml
+      resource: terraform-yaml-production
+  - task: logsearch-manifest
+    config:
+      <<: *manifest-config
+      run:
+        path: sh
+        args:
+        - -exc
+        - |
+          SPRUCE_FILE_BASE_PATH=logsearch-config spruce merge \
+            --prune terraform_outputs \
+            logsearch-config/logsearch-platform-deployment.yml \
+            logsearch-config/logsearch-platform-jobs.yml \
+            logsearch-config/logsearch-platform-elastalert.yml \
+            common-secrets/secrets.yml \
+            logsearch-config/logsearch-platform-production.yml \
+            terraform-yaml/state.yml \
+            > logsearch-manifest/manifest.yml
+      outputs:
+      - name: logsearch-manifest
+  - *lint-manifest
+  - put: logsearch-platform-production-deployment
+    params: &deploy-params-platform
+      cert: common/master-bosh.crt
+      manifest: logsearch-manifest/manifest.yml
+      releases:
+      - logsearch-release/*.tgz
+      - logsearch-for-cloudfoundry-release/*.tgz
+      - elastalert-release/*.tgz
+      stemcells:
+      - logsearch-stemcell/*.tgz
+  on_failure:
+    put: slack
+    params:
+      <<: *slack-params
+      text: |
+        :x: FAILED to deploy platform logsearch on production
+        <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
+  on_success:
+    put: slack
+    params:
+      <<: *slack-params
+      text: |
+        :white_check_mark: Successfully deployed platform logsearch on production
+        <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
+
+- name: smoke-tests-platform-production
+  serial_groups: [bosh-platform-production]
+  plan:
+  - aggregate:
+    - get: common
+      resource: master-bosh-root-cert
+    - get: pipeline-tasks
+    - get: logsearch-platform-production-deployment
+      passed: [deploy-logsearch-platform-production]
+      trigger: true
+    - get: tests-timer
+      trigger: true
+  - task: smoke-tests
+    file: pipeline-tasks/bosh-errand.yml
+    params:
+      BOSH_TARGET: {{logsearch-production-deployment-bosh-target}}
+      BOSH_USERNAME: {{logsearch-production-deployment-bosh-username}}
+      BOSH_PASSWORD: {{logsearch-production-deployment-bosh-password}}
+      BOSH_DEPLOYMENT_NAME: logsearch-platform
+      BOSH_CACERT: common/master-bosh.crt
+      BOSH_ERRAND: smoke-tests
+      BOSH_FLAGS: "--keep-alive"
+  on_failure:
+    put: slack
+    params:
+      <<: *slack-params
+      text: |
+        :x: Smoke tests for platform logsearch on production FAILED
+        <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
+  on_success:
+    put: slack
+    params:
+      <<: *slack-params
+      channel: {{slack-news-channel}}
+      text: |
+        :white_check_mark: Smoke tests for platform logsearch on production PASSED
+        <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
+
+- name: smoke-tests-login-platform-production
+  serial_groups: [bosh-platform-production]
+  plan:
+  - aggregate:
+    - get: logsearch-config
+    - get: logsearch-production-deployment
+      trigger: true
+    - get: tests-timer
+      trigger: true
+  - task: smoke-tests-login
+    file: logsearch-config/smoke-tests-login.yml
+    params:
+      CF_USERNAME: {{cf-username-production}}
+      CF_PASSWORD: {{cf-password-production}}
+      CF_SYSTEM_DOMAIN: {{cf-system-domain-production}}
+  on_failure:
+    put: slack
+    params:
+      <<: *slack-params
+      text: |
+        :x: Login smoke tests for platform logsearch on production FAILED
+        <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
+  on_success:
+    put: slack
+    params:
+      <<: *slack-params
+      channel: {{slack-news-channel}}
+      text: |
+        :white_check_mark: Login smoke tests for platform logsearch on production PASSED
+        <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
+
+- name: upload-kibana-objects-platform-production
+  serial_groups: [bosh-platform-production]
+  plan:
+  - aggregate:
+    - get: common
+      resource: master-bosh-root-cert
+    - get: pipeline-tasks
+    - get: logsearch-platform-production-deployment
+      passed: [deploy-logsearch-platform-production]
+      trigger: true
+  - task: upload-kibana-objects
+    file: pipeline-tasks/bosh-errand.yml
+    params:
+      BOSH_TARGET: {{logsearch-production-deployment-bosh-target}}
+      BOSH_USERNAME: {{logsearch-production-deployment-bosh-username}}
+      BOSH_PASSWORD: {{logsearch-production-deployment-bosh-password}}
+      BOSH_DEPLOYMENT_NAME: logsearch-platform
+      BOSH_CACERT: common/master-bosh.crt
+      BOSH_ERRAND: upload-kibana-objects
+
 - name: deploy-logsearch-development
   serial_groups: [bosh-development]
   plan:
@@ -679,23 +985,23 @@ resources:
     bosh_cert: bosh.pem
     region: {{aws-region}}
 
-# - name: common-platform-staging
-#   type: cg-common
-#   source:
-#     bucket_name: {{logsearch-private-bucket-staging}}
-#     secrets_file: logsearch-platform.yml
-#     secrets_passphrase: {{logsearch-platform-staging-private-passphrase}}
-#     bosh_cert: bosh.pem
-#     region: {{aws-region}}
+- name: common-platform-staging
+  type: cg-common
+  source:
+    bucket_name: {{logsearch-private-bucket-staging}}
+    secrets_file: logsearch-platform.yml
+    secrets_passphrase: {{logsearch-platform-staging-private-passphrase}}
+    bosh_cert: bosh.pem
+    region: {{aws-region}}
 
-# - name: common-platform-production
-#   type: cg-common
-#   source:
-#     bucket_name: {{logsearch-private-bucket-production}}
-#     secrets_file: logsearch-platform.yml
-#     secrets_passphrase: {{logsearch-platform-production-private-passphrase}}
-#     bosh_cert: bosh.pem
-#     region: {{aws-region}}
+- name: common-platform-production
+  type: cg-common
+  source:
+    bucket_name: {{logsearch-private-bucket-production}}
+    secrets_file: logsearch-platform.yml
+    secrets_passphrase: {{logsearch-platform-production-private-passphrase}}
+    bosh_cert: bosh.pem
+    region: {{aws-region}}
 
 - &logsearch-release-tarball
   name: logsearch-release
@@ -784,17 +1090,17 @@ resources:
     <<: *bosh-params-development
     deployment: logsearch-platform
 
-# - name: logsearch-platform-staging-deployment
-#   type: 18f-bosh-deployment
-#   source:
-#     <<: *bosh-params-staging
-#     deployment: logsearch-platform
+- name: logsearch-platform-staging-deployment
+  type: 18f-bosh-deployment
+  source:
+    <<: *bosh-params-staging
+    deployment: logsearch-platform
 
-# - name: logsearch-platform-production-deployment
-#   type: 18f-bosh-deployment
-#   source:
-#     <<: *bosh-params-production
-#     deployment: logsearch-platform
+- name: logsearch-platform-production-deployment
+  type: 18f-bosh-deployment
+  source:
+    <<: *bosh-params-production
+    deployment: logsearch-platform
 
 - name: pipeline-tasks
   type: git

--- a/pipeline.yml
+++ b/pipeline.yml
@@ -43,6 +43,7 @@ jobs:
             --prune terraform_outputs \
             logsearch-config/logsearch-platform-deployment.yml \
             logsearch-config/logsearch-platform-jobs.yml \
+            logsearch-config/logsearch-platform-elastalert.yml \
             common-secrets/secrets.yml \
             logsearch-config/logsearch-platform-development.yml \
             terraform-yaml/state.yml \
@@ -102,7 +103,7 @@ jobs:
       BOSH_TARGET: {{logsearch-development-deployment-bosh-target}}
       BOSH_USERNAME: {{logsearch-development-deployment-bosh-username}}
       BOSH_PASSWORD: {{logsearch-development-deployment-bosh-password}}
-      BOSH_DEPLOYMENT_NAME: {{logsearch-development-deployment-bosh-deployment}}
+      BOSH_DEPLOYMENT_NAME: logsearch-platform
       BOSH_CACERT: common/master-bosh.crt
       BOSH_ERRAND: smoke-tests
       BOSH_FLAGS: "--keep-alive"
@@ -170,7 +171,7 @@ jobs:
       BOSH_TARGET: {{logsearch-development-deployment-bosh-target}}
       BOSH_USERNAME: {{logsearch-development-deployment-bosh-username}}
       BOSH_PASSWORD: {{logsearch-development-deployment-bosh-password}}
-      BOSH_DEPLOYMENT_NAME: {{logsearch-development-deployment-bosh-deployment}}
+      BOSH_DEPLOYMENT_NAME: logsearch-platform
       BOSH_CACERT: common/master-bosh.crt
       BOSH_ERRAND: upload-kibana-objects
 
@@ -264,7 +265,7 @@ jobs:
       BOSH_TARGET: {{logsearch-development-deployment-bosh-target}}
       BOSH_USERNAME: {{logsearch-development-deployment-bosh-username}}
       BOSH_PASSWORD: {{logsearch-development-deployment-bosh-password}}
-      BOSH_DEPLOYMENT_NAME: {{logsearch-development-deployment-bosh-deployment}}
+      BOSH_DEPLOYMENT_NAME: logsearch
       BOSH_CACERT: common/master-bosh.crt
       BOSH_ERRAND: smoke-tests
       BOSH_FLAGS: "--keep-alive"
@@ -332,7 +333,7 @@ jobs:
       BOSH_TARGET: {{logsearch-development-deployment-bosh-target}}
       BOSH_USERNAME: {{logsearch-development-deployment-bosh-username}}
       BOSH_PASSWORD: {{logsearch-development-deployment-bosh-password}}
-      BOSH_DEPLOYMENT_NAME: {{logsearch-development-deployment-bosh-deployment}}
+      BOSH_DEPLOYMENT_NAME: logsearch
       BOSH_CACERT: common/master-bosh.crt
       BOSH_ERRAND: upload-kibana-objects
 
@@ -411,7 +412,7 @@ jobs:
       BOSH_TARGET: {{logsearch-staging-deployment-bosh-target}}
       BOSH_USERNAME: {{logsearch-staging-deployment-bosh-username}}
       BOSH_PASSWORD: {{logsearch-staging-deployment-bosh-password}}
-      BOSH_DEPLOYMENT_NAME: {{logsearch-staging-deployment-bosh-deployment}}
+      BOSH_DEPLOYMENT_NAME: logsearch
       BOSH_CACERT: common/master-bosh.crt
       BOSH_ERRAND: smoke-tests
       BOSH_FLAGS: "--keep-alive"
@@ -478,7 +479,7 @@ jobs:
       BOSH_TARGET: {{logsearch-staging-deployment-bosh-target}}
       BOSH_USERNAME: {{logsearch-staging-deployment-bosh-username}}
       BOSH_PASSWORD: {{logsearch-staging-deployment-bosh-password}}
-      BOSH_DEPLOYMENT_NAME: {{logsearch-staging-deployment-bosh-deployment}}
+      BOSH_DEPLOYMENT_NAME: logsearch
       BOSH_CACERT: common/master-bosh.crt
       BOSH_ERRAND: upload-kibana-objects
 
@@ -563,7 +564,7 @@ jobs:
       BOSH_TARGET: {{logsearch-production-deployment-bosh-target}}
       BOSH_USERNAME: {{logsearch-production-deployment-bosh-username}}
       BOSH_PASSWORD: {{logsearch-production-deployment-bosh-password}}
-      BOSH_DEPLOYMENT_NAME: {{logsearch-production-deployment-bosh-deployment}}
+      BOSH_DEPLOYMENT_NAME: logsearch
       BOSH_CACERT: common/master-bosh.crt
       BOSH_ERRAND: smoke-tests
       BOSH_FLAGS: "--keep-alive"
@@ -630,7 +631,7 @@ jobs:
       BOSH_TARGET: {{logsearch-production-deployment-bosh-target}}
       BOSH_USERNAME: {{logsearch-production-deployment-bosh-username}}
       BOSH_PASSWORD: {{logsearch-production-deployment-bosh-password}}
-      BOSH_DEPLOYMENT_NAME: {{logsearch-production-deployment-bosh-deployment}}
+      BOSH_DEPLOYMENT_NAME: logsearch
       BOSH_CACERT: common/master-bosh.crt
       BOSH_ERRAND: upload-kibana-objects
 


### PR DESCRIPTION
Platform logsearch is like customer logsearch with a few differences:
* Kibana is exposed via elb rather than route registrar to simplify restricting to gsa network
* Use elb in front of ingestors to load-balance incoming logs
* No archiver, since cloudwatch logs will be ground truth
* No firehose-to-syslog
* Show platform dashboards rather than app logs
* Shorter retention interval

Will test on development after https://github.com/18F/cg-deploy-logsearch/pull/90 is done.