### PR TITLE
Use sequential static ips for masters.

### DIFF
--- a/logsearch-development.yml
+++ b/logsearch-development.yml
@@ -1,13 +1,4 @@
 instance_groups:
-- name: elasticsearch_master
-  instances: 3
-  networks:
-  - name: services
-    static_ips:
-    - (( grab terraform_outputs.logsearch_static_ips.[0]))
-    - (( grab terraform_outputs.logsearch_static_ips.[4]))
-    - (( grab terraform_outputs.logsearch_static_ips.[6]))
-
 - name: elasticsearch_data
   instances: 3
 

--- a/logsearch-jobs.yml
+++ b/logsearch-jobs.yml
@@ -3,7 +3,7 @@ instance_groups:
 #First deploy group - elasticsearch_master, maintenance
 #######################################################
 - name: elasticsearch_master
-  instances: 1
+  instances: 3
   jobs:
   - name: elasticsearch
     release: logsearch
@@ -54,6 +54,9 @@ instance_groups:
   networks:
   - name: services
     static_ips:
+    - (( grab terraform_outputs.logsearch_static_ips.[0]))
+    - (( grab terraform_outputs.logsearch_static_ips.[1]))
+    - (( grab terraform_outputs.logsearch_static_ips.[2]))
   vm_extensions: [logsearch-lb]
   update:
     max_in_flight: 1 # Should never update more than one ES master node at a time or cluster will go down

--- a/logsearch-production.yml
+++ b/logsearch-production.yml
@@ -1,13 +1,4 @@
 instance_groups:
-- name: elasticsearch_master
-  instances: 3
-  networks:
-  - name: services
-    static_ips:
-    - (( grab terraform_outputs.logsearch_static_ips.[0] ))
-    - (( grab terraform_outputs.logsearch_static_ips.[6] ))
-    - (( grab terraform_outputs.logsearch_static_ips.[7] ))
-
 - name: archiver
   instances: 3
   jobs:

--- a/logsearch-staging.yml
+++ b/logsearch-staging.yml
@@ -1,13 +1,4 @@
 instance_groups:
-- name: elasticsearch_master
-  instances: 3
-  networks:
-  - name: services
-    static_ips:
-    - (( grab terraform_outputs.logsearch_static_ips.[0]))
-    - (( grab terraform_outputs.logsearch_static_ips.[4]))
-    - (( grab terraform_outputs.logsearch_static_ips.[6]))
-
 - name: archiver
   instances: 1
   jobs:


### PR DESCRIPTION
To avoid conflicts between logsearch deployments, and for sanity.