### PR TITLE
Bump kibana post-start timeout.

### DIFF
--- a/logsearch-jobs.yml
+++ b/logsearch-jobs.yml
@@ -190,6 +190,8 @@ instance_groups:
         env:
         - NODE_ENV: production
         source_files: [/var/vcap/jobs/kibana-auth-plugin/config/config.sh]
+        health:
+          timeout: 600
   - name: kibana-auth-plugin
     release: logsearch-for-cloudfoundry
     properties:

--- a/logsearch-platform-jobs.yml
+++ b/logsearch-platform-jobs.yml
@@ -144,6 +144,8 @@ instance_groups:
         default_app_id: "dashboard/Platform-Overview"
         env:
         - NODE_ENV: production
+        health:
+          timeout: 600
   vm_type: logsearch_kibana
   vm_extensions: [platform-kibana-lb]
   stemcell: default


### PR DESCRIPTION
Building javascript assets can take more than five minutes and fail a
logsearch deploy.