### PR TITLE
Increase time to allow disk migrations to finish

### DIFF
--- a/logsearch-deployment.yml
+++ b/logsearch-deployment.yml
@@ -4,7 +4,7 @@ update:
   serial: false
   canaries: 1
   canary_watch_time: 30000-600000
-  update_watch_time: 5000-600000
+  update_watch_time: 5000-6000000
   max_in_flight: 1
   max_errors: 1
 


### PR DESCRIPTION
- Leave the canary time as is, so software releases timeout as normal
- Increase the actual update timeout, so that disk migrations are allowed to finish