### PR TITLE
Drop platform logs instance count.

### DIFF
--- a/logsearch-platform-jobs.yml
+++ b/logsearch-platform-jobs.yml
@@ -102,7 +102,7 @@ instance_groups:
 #2nd deploy group - elasticsearch_data, kibana, ingestors
 #########################################################
 - name: elasticsearch_data
-  instances: 8
+  instances: 5
   jobs:
   - name: elasticsearch
     release: logsearch


### PR DESCRIPTION
We shouldn't need so many instances after dropping log volume.