### PR TITLE
[WIP] Consume nats properties from cross-deployment link.

### DIFF
--- a/logsearch-development.yml
+++ b/logsearch-development.yml
@@ -36,6 +36,10 @@ instance_groups:
           api_endpoint: https://api.dev.us-gov-west-1.aws-us-gov.cloud.gov
           system_domain: dev.us-gov-west-1.aws-us-gov.cloud.gov
   - name: route_registrar
+    consumes:
+      nats:
+        from: nats
+        deployment: cf-development
     properties:
       route_registrar:
         routes:

--- a/logsearch-production.yml
+++ b/logsearch-production.yml
@@ -24,6 +24,10 @@ instance_groups:
           api_endpoint: https://api.fr.cloud.gov
           system_domain: fr.cloud.gov
   - name: route_registrar
+    consumes:
+      nats:
+        from: nats
+        deployment: cf-staging
     properties:
       route_registrar:
         routes:

--- a/logsearch-staging.yml
+++ b/logsearch-staging.yml
@@ -24,6 +24,10 @@ instance_groups:
           api_endpoint: https://api.fr-stage.cloud.gov
           system_domain: fr-stage.cloud.gov
   - name: route_registrar
+    consumes:
+      nats:
+        from: nats
+        deployment: cf-staging
     properties:
       route_registrar:
         routes:


### PR DESCRIPTION
Note: don't merge until migration to cf-deployment.