### PR TITLE
consolidate secrets buckets and regularize naming of secrets files

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -273,7 +273,7 @@ jobs:
             logsearch-config/logsearch-platform-deployment.yml \
             logsearch-config/logsearch-platform-jobs.yml \
             logsearch-config/elastalert/logsearch-platform-elastalert.yml \
-            common-secrets/logsearch-platform.yml \
+            common-secrets/logsearch-platform-staging.yml \
             logsearch-config/logsearch-platform-staging.yml \
             terraform-yaml/state.yml \
             > logsearch-manifest/manifest.yml
@@ -429,7 +429,7 @@ jobs:
             logsearch-config/logsearch-platform-deployment.yml \
             logsearch-config/logsearch-platform-jobs.yml \
             logsearch-config/elastalert/logsearch-platform-elastalert.yml \
-            common-secrets/logsearch-platform.yml \
+            common-secrets/logsearch-platform-production.yml \
             logsearch-config/logsearch-platform-production.yml \
             terraform-yaml/state.yml \
             > logsearch-manifest/manifest.yml
@@ -767,7 +767,7 @@ jobs:
             logsearch-config/logsearch-deployment.yml \
             logsearch-config/logsearch-jobs.yml \
             logsearch-config/elastalert/logsearch-elastalert.yml \
-            common-secrets/logsearch.yml \
+            common-secrets/logsearch-staging.yml \
             logsearch-config/logsearch-staging.yml \
             terraform-yaml/state.yml \
             > logsearch-manifest/manifest.yml
@@ -950,7 +950,7 @@ jobs:
             logsearch-config/logsearch-deployment.yml \
             logsearch-config/logsearch-jobs.yml \
             logsearch-config/elastalert/logsearch-elastalert.yml \
-            common-secrets/logsearch.yml \
+            common-secrets/logsearch-production.yml \
             logsearch-config/logsearch-production.yml \
             terraform-yaml/state.yml \
             > logsearch-manifest/manifest.yml
@@ -1096,50 +1096,50 @@ resources:
 - name: master-bosh-root-cert
   type: s3-iam
   source:
-    bucket: {{logsearch-private-bucket-production}}
+    bucket: {{logsearch-private-bucket}}
     region_name: {{aws-region}}
     versioned_file: master-bosh.crt
 
 - name: common-development
   type: s3-iam
   source:
-    bucket: {{logsearch-private-bucket-development}}
+    bucket: {{logsearch-private-bucket}}
     versioned_file: logsearch-development.yml
     region_name: {{aws-region}}
 
 - name: common-staging
   type: s3-iam
   source:
-    bucket: {{logsearch-private-bucket-staging}}
-    versioned_file: logsearch.yml
+    bucket: {{logsearch-private-bucket}}
+    versioned_file: logsearch-staging.yml
     region_name: {{aws-region}}
 
 - name: common-prod
   type: s3-iam
   source:
-    bucket: {{logsearch-private-bucket-production}}
-    versioned_file: logsearch.yml
+    bucket: {{logsearch-private-bucket}}
+    versioned_file: logsearch-production.yml
     region_name: {{aws-region}}
 
 - name: common-platform-development
   type: s3-iam
   source:
-    bucket: {{logsearch-private-bucket-development}}
+    bucket: {{logsearch-private-bucket}}
     versioned_file: logsearch-platform-development.yml
     region_name: {{aws-region}}
 
 - name: common-platform-staging
   type: s3-iam
   source:
-    bucket: {{logsearch-private-bucket-staging}}
-    versioned_file: logsearch-platform.yml
+    bucket: {{logsearch-private-bucket}}
+    versioned_file: logsearch-platform-staging.yml
     region_name: {{aws-region}}
 
 - name: common-platform-production
   type: s3-iam
   source:
-    bucket: {{logsearch-private-bucket-production}}
-    versioned_file: logsearch-platform.yml
+    bucket: {{logsearch-private-bucket}}
+    versioned_file: logsearch-platform-production.yml
     region_name: {{aws-region}}
 
 - &logsearch-release-tarball

--- a/credentials.example.yml
+++ b/credentials.example.yml
@@ -7,15 +7,14 @@ cg-deploy-logsearch-git-branch: master
 event-logger-app-git-url: https://github.com/18F/cf-app-events-logger.git
 event-logger-app-git-branch: master
 cg-s3-bosh-releases-bucket:
+logsearch-private-bucket:
 
-logsearch-private-bucket-staging:
 logsearch-staging-deployment-bosh-target:
 logsearch-staging-deployment-bosh-username:
 logsearch-staging-deployment-bosh-password:
 logsearch-staging-deployment-bosh-deployment:
 logsearch-staging-private-passphrase:
 
-logsearch-private-bucket-production:
 logsearch-production-deployment-bosh-target:
 logsearch-production-deployment-bosh-username:
 logsearch-production-deployment-bosh-password:


### PR DESCRIPTION
The staging secrets bucket causes confusion and so @rogeruiz suggested that I go fix that up in all our deployments.  As soon as this is approved, I will fly the pipeline for this.  The secrets files should all be copied over and ready to go.