### PR TITLE
Increase cloud controller polling interval.

### DIFF
--- a/logsearch-jobs.yml
+++ b/logsearch-jobs.yml
@@ -255,6 +255,7 @@ instance_groups:
         - LogMessage
         - ContainerMetric
         firehose_client_id: logsearch_firehose_ingestor
+        firehose_cc_pull_interval: 300s
         skip_ssl_validation: false
       syslog:
         host: 127.0.0.1
@@ -301,6 +302,7 @@ instance_groups:
         - LogMessage
         - ContainerMetric
         firehose_client_id: logsearch_firehose_ingestor
+        firehose_cc_pull_interval: 300s
         skip_ssl_validation: false
       syslog:
         host: 127.0.0.1


### PR DESCRIPTION
With the current release of firehose-to-syslog, the default polling
interval spikes cpu on api instances. Until upstream fixes the issue, we
can poll at a longer interval.