### PR TITLE
Add Content-Type header for JSON

### DIFF
--- a/cronjobs/slow-logs.sh
+++ b/cronjobs/slow-logs.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-curl -XPUT ${HOST}:9200/_all/_settings -d @<(cat <<JSON
+curl -H 'Content-Type: application/json' -XPUT ${HOST}:9200/_all/_settings -d @<(cat <<JSON
 {
   "index.search.slowlog.threshold.query.info": "5s",
   "index.search.slowlog.threshold.fetch.info": "5s"


### PR DESCRIPTION
:eyes: https://www.elastic.co/blog/strict-content-type-checking-for-elasticsearch-rest-requests

Related to cloudfoundry-community/logsearch-boshrelease#125