### PR TITLE
Adding signature_name checks for null

### DIFF
--- a/elastalert/logsearch-platform-elastalert.yml
+++ b/elastalert/logsearch-platform-elastalert.yml
@@ -98,3 +98,6 @@ instance_groups:
                       "@source.component": "clamd"
                   - match:
                       "event_type": "ScanOnAccess"
+                  - not:
+                      term:
+                        "signature_name": "null"


### PR DESCRIPTION
ClamAV alerts without a signature_name are useless.