### PR TITLE
Use blocks in YAML to make logstash-filters human-readable

### DIFF
--- a/logsearch-filters.yml
+++ b/logsearch-filters.yml
@@ -3,8 +3,547 @@ properties:
   <<: (( merge ))
   logstash_parser:
     <<: (( merge ))
-    filters: "# All logs start being sent to the unparsed index.  \n# The filters below will route them to the @index=app or @index=platform\nif ! [@metadata][index] {\n    mutate {\n        add_field => { \"[@metadata][index]\" => \"unparsed\" }\n        add_field => { \"[@metadata][type]\" => \"%{[@type]}\" }\n    }\n}\n\nif [@metadata][type] in [\"syslog\", \"relp\"] and [syslog_program] == \"doppler\" {\n# Parse Cloud Foundry logs from doppler firehose (via https://github.com/SpringerPE/firehose-to-syslog)\n\njson {\n    source => 'syslog_message'\n}\n\nif \"_jsonparsefailure\" in [tags] {\n\n    # Amend the failure tag to match our fail/${addon}/${filter}/${detail} standard\n    mutate {\n        add_tag => [\"fail/cloudfoundry/firehose/jsonparsefailure_of_syslog_message\"]\n        remove_tag => [\"_jsonparsefailure\"]\n    }\n\n} else {\n\n    date {\n        match => [ \"time\", \"ISO8601\" ]\n    }\n\n    if [@message] =~ /^\\{/ {\n        json {\n            source => \"@message\"\n            target => \"parsed_json_data\"\n            remove_field => [\"@message\"]\n        }\n        if \"_jsonparsefailure\" in [tags] {\n\n            mutate {\n              remove_tag => [ \"_jsonparsefailure\" ]\n            }\n\n        } else {\n            mutate {\n                rename => { \"[parsed_json_data][event_type]\" => \"[event_type]\" }\n            }\n            #Ensure that we always have an event_type, in prep for adding metrics\n            if ![event_type] {\n                mutate {\n                    add_field => [ \"event_type\", \"LogMessage\" ]\n                }\n            }\n\n            if [event_type] == \"ContainerMetric\" {\n              mutate {\n                add_tag => \"ContainerMetric\"\n                add_field => {\"[@source][component]\" => \"METRIC\"}\n                add_field => {\"[@source][instance]\" => \"%{[parsed_json_data][instance_index]}\"}\n              }\n\n              mutate {\n                rename => { \"[parsed_json_data][cpu_percentage]\" => \"[container][cpu_percentage]\" }\n                rename => { \"[parsed_json_data][memory_bytes]\" => \"[container][memory_bytes]\" }\n                rename => { \"[parsed_json_data][disk_bytes]\" => \"[container][disk_bytes]\" }\n              }\n            }\n            mutate {\n                rename => { \"[parsed_json_data][cf_app_id]\" => \"[@source][app][id]\" }\n                rename => { \"[parsed_json_data][cf_app_name]\" => \"[@source][app][name]\" }\n                rename => { \"[parsed_json_data][cf_space_id]\" => \"[@source][space][id]\" }\n                rename => { \"[parsed_json_data][cf_space_name]\" => \"[@source][space][name]\" }\n                rename => { \"[parsed_json_data][cf_org_id]\" => \"[@source][org][id]\" }\n                rename => { \"[parsed_json_data][cf_org_name]\" => \"[@source][org][name]\" }\n\n                rename => { \"[parsed_json_data][level]\" => \"[@level]\" }\n                uppercase => [ \"[@level]\" ]\n\n                rename => { \"[host]\" => \"[@source][host]\" }\n                rename => { \"[parsed_json_data][source_type]\" => \"[@source][component]\" }\n                rename => { \"[parsed_json_data][source_instance]\" => \"[@source][instance]\" }\n                add_field => { \"[@source][name]\" => \"%{[@source][component]}/%{[@source][instance]}\" }\n                convert => { \"[@source][instance]\" => \"integer\" }\n\n                rename => { \"[parsed_json_data][message_type]\" => \"[@source][message_type]\" }\n                rename => { \"[parsed_json_data][origin]\" => \"[@source][origin]\" }\n\n                rename => { \"[parsed_json_data][msg]\" => \"[@message]\" }\n                remove_field => [ \"parsed_json_key\", \"parsed_json_data\" ]\n            }\n        }\n    }\n\n    # Replace the unicode newline character \\u2028 with \\n, which Kibana will display as a new line.  Seems that passing a string with an actual newline in it is the only way to make gsub work\n    mutate {\n      gsub => [ \"[@message]\", '\\u2028', \"\n\"\n      ]\n    }\n\n    if ('RTR' in [@source][component]) {\n        grok {\n\n            #cf-release > v222 - includes x_forwarded_proto\n            match => { '@message' => '%{HOSTNAME:[RTR][hostname]} - \\[(?<time>%{MONTHDAY}/%{MONTHNUM}/%{YEAR}:%{TIME} %{INT})\\] \\\"%{WORD:[RTR][verb]} %{URIPATHPARAM:[RTR][path]} %{PROG:[RTR][http_spec]}\\\" %{BASE10NUM:[RTR][status]:int} %{BASE10NUM:[RTR][request_bytes_received]:int} %{BASE10NUM:[RTR][body_bytes_sent]:int} \\\"%{GREEDYDATA:[RTR][referer]}\\\" \\\"%{GREEDYDATA:[RTR][http_user_agent]}\\\" %{HOSTPORT} x_forwarded_for:\\\"%{GREEDYDATA:[RTR][x_forwarded_for]}\\\" x_forwarded_proto:\\\"%{NOTSPACE:[RTR][x_forwarded_proto]}\\\" vcap_request_id:%{NOTSPACE:[RTR][vcap_request_id]} response_time:%{NUMBER:[RTR][response_time_sec]:float} app_id:%{NOTSPACE}%{GREEDYDATA}' }\n\n            #cf-release > v205 - includes RequestBytesReceived\n            match => { '@message' => '%{HOSTNAME:[RTR][hostname]} - \\[(?<time>%{MONTHDAY}/%{MONTHNUM}/%{YEAR}:%{TIME} %{INT})\\] \\\"%{WORD:[RTR][verb]} %{URIPATHPARAM:[RTR][path]} %{PROG:[RTR][http_spec]}\\\" %{BASE10NUM:[RTR][status]:int} %{BASE10NUM:[RTR][request_bytes_received]:int} %{BASE10NUM:[RTR][body_bytes_sent]:int} \\\"%{GREEDYDATA:[RTR][referer]}\\\" \\\"%{GREEDYDATA:[RTR][http_user_agent]}\\\" %{HOSTPORT} x_forwarded_for:\\\"%{GREEDYDATA:[RTR][x_forwarded_for]}\\\" vcap_request_id:%{NOTSPACE:[RTR][vcap_request_id]} response_time:%{NUMBER:[RTR][response_time_sec]:float} app_id:%{NOTSPACE}%{GREEDYDATA}' }\n\n            #cf-release <= v205\n            match => { '@message' => '%{HOSTNAME:[RTR][hostname]} - \\[(?<time>%{MONTHDAY}/%{MONTHNUM}/%{YEAR}:%{TIME} %{INT})\\] \\\"%{WORD:[RTR][verb]} %{URIPATHPARAM:[RTR][path]} %{PROG:[RTR][http_spec]}\\\" %{BASE10NUM:[RTR][status]:int} %{BASE10NUM:[RTR][body_bytes_sent]:int} \\\"%{GREEDYDATA:[RTR][referer]}\\\" \\\"%{GREEDYDATA:[RTR][http_user_agent]}\\\" %{HOSTPORT} x_forwarded_for:\\\"%{GREEDYDATA:[RTR][x_forwarded_for]}\\\" vcap_request_id:%{NOTSPACE:[RTR][vcap_request_id]} response_time:%{NUMBER:[RTR][response_time_sec]:float} app_id:%{NOTSPACE}%{GREEDYDATA}' }\n            overwrite => [ \"time\" ]\n            tag_on_failure => [ 'fail/firehose/RTR' ]\n            add_tag => \"RTR\"\n        }\n\n        if !(\"fail/firehose/RTR\" in [tags]) {\n            date {\n                match => [ \"time\", \"dd/MM/y:HH:mm:ss Z\" ]\n            }\n\n            # set @level based on HTTP status\n            if [RTR][status] >= 500 {\n                mutate {\n                    replace => { \"[@level]\" => \"ERROR\" }\n                }\n            } else if [RTR][status] >= 400 {\n                mutate {\n                    replace => { \"[@level]\" => \"WARN\" }\n                }\n            }\n\n\n            if [RTR][x_forwarded_for] {\n                mutate {\n                    gsub => [\"[RTR][x_forwarded_for]\",\"[\\s\\\\\"]\",\"\"] # remove quotes and whitespace\n                    split => [\"[RTR][x_forwarded_for]\", \",\"] # format is client, proxy1, proxy2 ...\n                }\n\n               ruby {\n                   code => \"event['RTR']['response_time_ms'] = (event['RTR']['response_time_sec']*1000).to_int\"\n                   remove_field => \"response_time_sec\"\n               }\n\n               mutate {\n                  add_field => [\"[RTR][remote_addr]\", \"%{[RTR][x_forwarded_for][0]}\"]\n               }\n\n               if ([RTR][remote_addr] =~ /([0-9]{1,3}\\.){3}[0-9]{1,3}/) {\n                   geoip {\n                     source => \"[RTR][remote_addr]\"\n                   }\n               }\n            }\n        }\n    }\n\n    # Cleanup unused fields\n    mutate {\n        remove_field => \"time\"\n        remove_field => \"timestamp\"\n        remove_field => \"received_from\"\n        remove_field => \"received_at\"\n        remove_field => \"syslog_message\"\n        remove_field => \"syslog_severity_code\"\n        remove_field => \"syslog_facility_code\"\n        remove_field => \"syslog_facility\"\n        remove_field => \"syslog_severity\"\n        remove_field => \"syslog_pri\"\n        remove_field => \"syslog_program\"\n        remove_field => \"syslog_pid\"\n        remove_field => \"syslog_hostname\"\n        remove_field => \"syslog_timestamp\"\n    }\n\n    #Route to index and type\n    mutate {\n        replace => { \"[@metadata][index]\" => \"app\" }\n        replace => { \"[@metadata][type]\" => \"%{[event_type]}\" }\n        remove_field => \"[event_type]\"\n        add_tag => [ 'firehose' ]\n    }\n\n}\n\n  if \"firehose\" in [tags] {\n    # Parse messages from /v2/events api logged by https://github.com/stayup-io/cf-app-events-logger \n\nif [@message] =~ /.*\"event_type\":\"AppEvent\".*/  {\n\n    json {\n        source => \"[@message]\"\n        target => \"[app_event]\"\n        add_tag => \"app_event\"\n    }\n\n    date {\n        match => [ \"[app_event][timestamp]\", \"ISO8601\" ]\n    }\n\n    ruby {\n        code => \"event['@metadata']['app_event_metadata_as_string'] = event['app_event']['metadata'].to_s\"\n    }\n    mutate {\n        replace => { \"[@message]\" => \"%{[app_event][type]} %{[@metadata][app_event_metadata_as_string]}\" }\n    }\n\n    mutate {\n        replace => { \"[@source][component]\" => \"AppEvent\" }\n        replace => { \"[@source][instance]\" => \"0\" }\n        convert => { \"[@source][instance]\" => \"integer\" }\n        replace => { \"[@source][name]\" => \"AppEvent/0\" }\n\n        replace => { \"[@source][app][id]\" => \"%{[app_event][app_id]}\" }\n        replace => { \"[@source][app][name]\" => \"%{[app_event][app_name]}\" }\n        replace => { \"[@source][space][id]\" => \"%{[app_event][space_guid]}\" }\n        replace => { \"[@source][space][name]\" => \"%{[app_event][space_name]}\" }\n        replace => { \"[@source][org][id]\" => \"%{[app_event][organization_guid]}\" }\n        replace => { \"[@source][org][name]\" => \"%{[app_event][organization_name]}\" }\n\n        replace => { \"[@metadata][type]\" => \"app_event\" }\n\n        remove_field => [ \"[@source][message_type]\", \"[@source][origin]\", \"[@source][host]\" ]\n    }\n\n}\n\n\n  }\n} else if [@metadata][type] in [\"syslog\", \"relp\"] and [@source.host] == \"loggregator\" {\n# Parse Cloud Foundry logs from loggregator (syslog)\n# see https://github.com/cloudfoundry/loggregator/blob/master/src/loggregator/sinks/syslogwriter/syslog_writer.go#L156\n\nmutate {\n    add_field => [ \"tmp_syslog_procid\" ,\"%{syslog_procid}\" ]\n}\n\n# [App/0] => [App, 0]\nmutate {\n    gsub => [ \"tmp_syslog_procid\", \"[\\[\\]]\", \"\" ]\n    split => [ \"tmp_syslog_procid\", \"/\" ]\n    add_field => [ \"source_type\" ,\"%{[tmp_syslog_procid][0]}\"  ]\n    add_field => [ \"source_instance\" ,\"%{[tmp_syslog_procid][1]}\"  ]\n    remove_field => [ \"tmp_syslog_procid\" ]\n}\n\n# For source types with no instance number, remove the field\nif [source_instance] == \"%{[tmp_syslog_procid][1]}\" {\n    mutate {\n      remove_field => [ \"source_instance\" ]\n    }\n}\n\n#If it looks like JSON, it must be JSON...\nif [syslog_message] =~ /^\\s*{\".*}\\s*$/ {\n    json {\n        source => \"syslog_message\"\n    }\n     # @todo seems like some messages have @timestamp in them? seems ci-specific\n    date {\n        match => [ \"@timestamp\", \"ISO8601\" ]\n    }\n} else {\n    mutate {\n        add_field => [ \"message\", \"%{syslog_message}\" ]\n    }\n    if [message] == \"-\" {\n        mutate {\n            remove_field => \"message\"\n        }\n    }\n}\n mutate {\n    rename => [ \"syslog_program\", \"@source.app_id\" ]\n}\n mutate {\n    add_tag => \"cloudfoundry_loggregator\"\n    remove_field => \"syslog_facility\"\n    remove_field => \"syslog_facility_code\"\n    remove_field => \"syslog_message\"\n    remove_field => \"syslog_severity\"\n    remove_field => \"syslog_severity_code\"\n    remove_field => \"syslog5424_ver\"\n    remove_field => \"syslog6587_msglen\"\n}\n\n} else if [@metadata][type] in [\"syslog\", \"relp\"] and [syslog_program] == \"vcap.uaa\" {\ngrok {\n    match => { \"syslog_message\" =>\n    \"\\[job=%{NOTSPACE:jobname}%{SPACE}index=%{NOTSPACE:jobindex}\\]%{SPACE}\\[%{TIMESTAMP_ISO8601:uaa_timestamp}\\]%{SPACE}uaa%{SPACE}-%{SPACE}%{NUMBER:pid:int}%{SPACE}\\[%{DATA:thread_name}\\]%{SPACE}....%{SPACE}%{LOGLEVEL:loglevel}%{SPACE}---%{SPACE}Audit:%{SPACE}%{WORD:audit_event_type}%{SPACE}\\('%{DATA:audit_event_data}'\\):%{SPACE}principal=%{DATA:audit_event_principal},%{SPACE}origin=\\[%{DATA:audit_event_origin}\\],%{SPACE}identityZoneId=\\[%{DATA:audit_event_identity_zone_id}\\]\"\n    }\n    tag_on_failure => [\n        \"fail/cloudfoundry/uaa-audit\"\n    ]\n    add_tag => \"uaa-audit\"\n}\n\nif !(\"fail/cloudfoundry/uaa-audit\" in [tags]) {\n    date {\n        match => [ \"uaa_timestamp\", \"ISO8601\" ]\n        remove_field => \"uaa_timestamp\"\n    }\n\n    if \"PrincipalAuthenticationFailure\" == [audit_event_type] {\n        mutate {\n            add_field => { \"audit_event_remote_address\" => \"%{audit_event_origin}\" }\n       }\n    }\n\n    if [audit_event_origin] =~ /remoteAddress=/ {\n        grok {\n            match => { \"audit_event_origin\" => \"remoteAddress=%{IP:audit_event_remote_address}\" }\n        }\n    }\n\n    if [audit_event_remote_address] {\n       geoip {\n          source => \"audit_event_remote_address\"\n       }\n    }\n\n    mutate {\n        remove_field => \"syslog_pri\"\n        remove_field => \"syslog_facility\"\n        remove_field => \"syslog_facility_code\"\n        remove_field => \"syslog_message\"\n        remove_field => \"syslog_severity\"\n        remove_field => \"syslog_severity_code\"\n        remove_field => \"syslog_program\"\n        remove_field => \"syslog_timestamp\"\n        remove_field => \"syslog_hostname\"\n\n        split =>  { \"audit_event_origin\" => \", \" }\n        \n        add_field => { \"[@source][component]\" => \"UAA\" }\n        add_field => { \"[@source][name]\" => \"%{jobname}/%{jobindex}\" }\n        convert => { \"jobindex\" => \"integer\" }\n    }\n    \n    mutate {\n        remove_field => \"jobname\"\n        rename => { \"jobindex\"       => \"[@source][instance]\" }\n        rename => { \"loglevel\"       => \"[@level]\" }\n\n        rename => { \"pid\"            => \"[UAA][pid]\" }\n        rename => { \"thread_name\"     => \"[UAA][thread_name]\" }\n\n        rename => { \"audit_event_type\"              => \"[UAA][type]\" }\n        rename => { \"audit_event_remote_address\"    => \"[UAA][remote_address]\" }\n        rename => { \"audit_event_data\"              => \"[UAA][data]\" }\n        rename => { \"audit_event_principal\"         => \"[UAA][principal]\" }\n        rename => { \"audit_event_origin\"            => \"[UAA][origin]\" }\n        rename => { \"audit_event_identity_zone_id\"  => \"[UAA][identity_zone_id]\" }\n    }\n\n    #Route to index and type\n    mutate {\n        replace => { \"[@metadata][index]\" => \"platform\" }\n        replace => { \"[@metadata][type]\" => \"uaa-audit\" }\n        add_tag => \"uaa\"\n        add_tag => \"audit\"\n    }\n}\n\n\n} else if \"collector\" in [tags] {\n# Parse Cloud Foundry Collector\n\nmutate {\n    add_field => { \"[@source][component]\" => \"%{[attributes][job]}\" }\n    add_field => { \"[@source][instance]\" => \"%{[attributes][index]}\" }\n    add_field => { \"[@source][deployment]\" => \"%{[attributes][deployment]}\" }\n    add_field => { \"[@source][host]\" => \"%{[attributes][ip]}\" }\n    remove_field => [ \"[attributes]\" ]\n}\n\nmutate {\n    add_field => { \"[@source][name]\" => \"%{[@source][component]}/%{[@source][instance]}\" }\n}\n\nmutate {\n    rename => { \"[key]\" => \"[metric][key]\" }\n    convert => { \"[value]\" => \"string\" }\n}\n\nif [value] =~ /^[-+]?\\d{1,19}$/ {\n    mutate {\n        rename => { \"[value]\" => \"[metric][value_int]\" }\n        convert => { \"[metric][value_int]\" => \"integer\" }\n    }\n} else {\n    mutate {\n        rename => { \"[value]\" => \"[metric][value_float]\" }\n        convert => { \"[metric][value_float]\" => \"float\" }\n    }\n}\n\nmutate {\n    remove_field => [ \"level\", \"facility\", \"file\", \"line\", \"version\", \"source_host\", \"host\" ]\n}\n\n#Route to index and type\nmutate {\n    replace => { \"[@metadata][index]\" => \"platform\" }\n    replace => { \"[@metadata][type]\" => \"metric\" }\n    add_tag => \"metric\"\n}\n\n} else if [@metadata][type] in [\"syslog\", \"relp\"] and [syslog_program] =~ /vcap\\..*/ {\n# Parse Cloud Foundry logs from syslog_aggregator\n\ngrok {\n    match => { \"syslog_message\" => \"(?:\\[job=%{NOTSPACE:[@job][name]}|-) +(?:index=%{NOTSPACE:[@job][index]}\\]|-) %{GREEDYDATA:_message_json}\" }\n    tag_on_failure => [\n        \"_grokparsefailure-cf-vcap\"\n    ]\n}\n\nif !(\"_grokparsefailure-cf-vcap\" in [tags]) {\n    kv {\n        source => \"msgdata\"\n        field_split => \" \"\n        target => \"msgdata\"\n    }\n\n    json {\n        source => \"_message_json\"\n        remove_field => \"_message_json\"\n    }\n\n    mutate {\n        rename => [ \"syslog_program\", \"[@shipper][name]\" ]\n        replace => [ \"[@job][host]\", \"%{[@source][host]}\" ]\n        gsub => [\n            \"[@shipper][name]\", \"\\.\", \"_\",\n            \"[@job][name]\", \"\\.\", \"_\"\n          ]\n    }\n\n    if [source] == \"NatsStreamForwarder\" {\n        json {\n            source => \"[data][nats_message]\"\n            target => \"nats_message\"\n        }\n\n        mutate {\n            remove_field => \"[data][nats_message]\"\n        }\n    }\n\n    mutate {\n        add_tag => \"cloudfoundry_vcap\"\n        replace => [ \"[@shipper][priority]\", \"%{syslog_pri}\" ]\n        replace => [ \"[@shipper][name]\", \"%{[@shipper][name]}_%{[@metadata][type]}\" ]\n    }\n\n    mutate {\n        remove_field => \"syslog_facility\"\n        remove_field => \"syslog_facility_code\"\n        remove_field => \"syslog_message\"\n        remove_field => \"syslog_severity\"\n        remove_field => \"syslog_severity_code\"\n    }\n\n    mutate {\n        #replace => { \"[@metadata][index]\" => \"platform\" }\n        replace => { \"[@metadata][type]\" => \"%{[@metadata][type]}_cf\" }\n    }\n}\n\n}\n\n#Cleanup\nmutate {\n  rename => { \"[tags]\" => \"[@tags]\" }\n  remove_field => [ \"@version\" ]\n  remove_field => \"@type\" \n}\n"
+    filters: |
+      # All logs start being sent to the unparsed index.
+      # The filters below will route them to the @index=app or @index=platform
+      if ! [@metadata][index] {
+          mutate {
+              add_field => { "[@metadata][index]" => "unparsed" }
+              add_field => { "[@metadata][type]" => "%{[@type]}" }
+          }
+      }
+      
+      if [@metadata][type] in ["syslog", "relp"] and [syslog_program] == "doppler" {
+      # Parse Cloud Foundry logs from doppler firehose (via https://github.com/SpringerPE/firehose-to-syslog)
+      
+      json {
+          source => 'syslog_message'
+      }
+      
+      if "_jsonparsefailure" in [tags] {
+      
+          # Amend the failure tag to match our fail/${addon}/${filter}/${detail} standard
+          mutate {
+              add_tag => ["fail/cloudfoundry/firehose/jsonparsefailure_of_syslog_message"]
+              remove_tag => ["_jsonparsefailure"]
+          }
+      
+      } else {
+      
+          date {
+              match => [ "time", "ISO8601" ]
+          }
+      
+          if [@message] =~ /^\{/ {
+              json {
+                  source => "@message"
+                  target => "parsed_json_data"
+                  remove_field => ["@message"]
+              }
+              if "_jsonparsefailure" in [tags] {
+      
+                  mutate {
+                    remove_tag => [ "_jsonparsefailure" ]
+                  }
+      
+              } else {
+                  mutate {
+                      rename => { "[parsed_json_data][event_type]" => "[event_type]" }
+                  }
+                  #Ensure that we always have an event_type, in prep for adding metrics
+                  if ![event_type] {
+                      mutate {
+                          add_field => [ "event_type", "LogMessage" ]
+                      }
+                  }
+      
+                  if [event_type] == "ContainerMetric" {
+                    mutate {
+                      add_tag => "ContainerMetric"
+                      add_field => {"[@source][component]" => "METRIC"}
+                      add_field => {"[@source][instance]" => "%{[parsed_json_data][instance_index]}"}
+                    }
+      
+                    mutate {
+                      rename => { "[parsed_json_data][cpu_percentage]" => "[container][cpu_percentage]" }
+                      rename => { "[parsed_json_data][memory_bytes]" => "[container][memory_bytes]" }
+                      rename => { "[parsed_json_data][disk_bytes]" => "[container][disk_bytes]" }
+                    }
+                  }
+                  mutate {
+                      rename => { "[parsed_json_data][cf_app_id]" => "[@source][app][id]" }
+                      rename => { "[parsed_json_data][cf_app_name]" => "[@source][app][name]" }
+                      rename => { "[parsed_json_data][cf_space_id]" => "[@source][space][id]" }
+                      rename => { "[parsed_json_data][cf_space_name]" => "[@source][space][name]" }
+                      rename => { "[parsed_json_data][cf_org_id]" => "[@source][org][id]" }
+                      rename => { "[parsed_json_data][cf_org_name]" => "[@source][org][name]" }
+      
+                      rename => { "[parsed_json_data][level]" => "[@level]" }
+                      uppercase => [ "[@level]" ]
+      
+                      rename => { "[host]" => "[@source][host]" }
+                      rename => { "[parsed_json_data][source_type]" => "[@source][component]" }
+                      rename => { "[parsed_json_data][source_instance]" => "[@source][instance]" }
+                      add_field => { "[@source][name]" => "%{[@source][component]}/%{[@source][instance]}" }
+                      convert => { "[@source][instance]" => "integer" }
+      
+                      rename => { "[parsed_json_data][message_type]" => "[@source][message_type]" }
+                      rename => { "[parsed_json_data][origin]" => "[@source][origin]" }
+      
+                      rename => { "[parsed_json_data][msg]" => "[@message]" }
+                      remove_field => [ "parsed_json_key", "parsed_json_data" ]
+                  }
+              }
+          }
+      
+          # Replace the unicode newline character \u2028 with \n, which Kibana will display as a new line.  Seems that passing a string with an actual newline in it is the only way to make gsub work
+          mutate {
+            gsub => [ "[@message]", '\u2028', "
+      "
+            ]
+          }
+      
+          if ('RTR' in [@source][component]) {
+              grok {
+      
+                  #cf-release > v222 - includes x_forwarded_proto
+                  match => { '@message' => '%{HOSTNAME:[RTR][hostname]} - \[(?<time>%{MONTHDAY}/%{MONTHNUM}/%{YEAR}:%{TIME} %{INT})\] \"%{WORD:[RTR][verb]} %{URIPATHPARAM:[RTR][path]} %{PROG:[RTR][http_spec]}\" %{BASE10NUM:[RTR][status]:int} %{BASE10NUM:[RTR][request_bytes_received]:int} %{BASE10NUM:[RTR][body_bytes_sent]:int} \"%{GREEDYDATA:[RTR][referer]}\" \"%{GREEDYDATA:[RTR][http_user_agent]}\" %{HOSTPORT} x_forwarded_for:\"%{GREEDYDATA:[RTR][x_forwarded_for]}\" x_forwarded_proto:\"%{NOTSPACE:[RTR][x_forwarded_proto]}\" vcap_request_id:%{NOTSPACE:[RTR][vcap_request_id]} response_time:%{NUMBER:[RTR][response_time_sec]:float} app_id:%{NOTSPACE}%{GREEDYDATA}' }
+      
+                  #cf-release > v205 - includes RequestBytesReceived
+                  match => { '@message' => '%{HOSTNAME:[RTR][hostname]} - \[(?<time>%{MONTHDAY}/%{MONTHNUM}/%{YEAR}:%{TIME} %{INT})\] \"%{WORD:[RTR][verb]} %{URIPATHPARAM:[RTR][path]} %{PROG:[RTR][http_spec]}\" %{BASE10NUM:[RTR][status]:int} %{BASE10NUM:[RTR][request_bytes_received]:int} %{BASE10NUM:[RTR][body_bytes_sent]:int} \"%{GREEDYDATA:[RTR][referer]}\" \"%{GREEDYDATA:[RTR][http_user_agent]}\" %{HOSTPORT} x_forwarded_for:\"%{GREEDYDATA:[RTR][x_forwarded_for]}\" vcap_request_id:%{NOTSPACE:[RTR][vcap_request_id]} response_time:%{NUMBER:[RTR][response_time_sec]:float} app_id:%{NOTSPACE}%{GREEDYDATA}' }
+      
+                  #cf-release <= v205
+                  match => { '@message' => '%{HOSTNAME:[RTR][hostname]} - \[(?<time>%{MONTHDAY}/%{MONTHNUM}/%{YEAR}:%{TIME} %{INT})\] \"%{WORD:[RTR][verb]} %{URIPATHPARAM:[RTR][path]} %{PROG:[RTR][http_spec]}\" %{BASE10NUM:[RTR][status]:int} %{BASE10NUM:[RTR][body_bytes_sent]:int} \"%{GREEDYDATA:[RTR][referer]}\" \"%{GREEDYDATA:[RTR][http_user_agent]}\" %{HOSTPORT} x_forwarded_for:\"%{GREEDYDATA:[RTR][x_forwarded_for]}\" vcap_request_id:%{NOTSPACE:[RTR][vcap_request_id]} response_time:%{NUMBER:[RTR][response_time_sec]:float} app_id:%{NOTSPACE}%{GREEDYDATA}' }
+                  overwrite => [ "time" ]
+                  tag_on_failure => [ 'fail/firehose/RTR' ]
+                  add_tag => "RTR"
+              }
+      
+              if !("fail/firehose/RTR" in [tags]) {
+                  date {
+                      match => [ "time", "dd/MM/y:HH:mm:ss Z" ]
+                  }
+      
+                  # set @level based on HTTP status
+                  if [RTR][status] >= 500 {
+                      mutate {
+                          replace => { "[@level]" => "ERROR" }
+                      }
+                  } else if [RTR][status] >= 400 {
+                      mutate {
+                          replace => { "[@level]" => "WARN" }
+                      }
+                  }
+      
+      
+                  if [RTR][x_forwarded_for] {
+                      mutate {
+                          gsub => ["[RTR][x_forwarded_for]","[\s\\"]",""] # remove quotes and whitespace
+                          split => ["[RTR][x_forwarded_for]", ","] # format is client, proxy1, proxy2 ...
+                      }
+      
+                     ruby {
+                         code => "event['RTR']['response_time_ms'] = (event['RTR']['response_time_sec']*1000).to_int"
+                         remove_field => "response_time_sec"
+                     }
+      
+                     mutate {
+                        add_field => ["[RTR][remote_addr]", "%{[RTR][x_forwarded_for][0]}"]
+                     }
+      
+                     if ([RTR][remote_addr] =~ /([0-9]{1,3}\.){3}[0-9]{1,3}/) {
+                         geoip {
+                           source => "[RTR][remote_addr]"
+                         }
+                     }
+                  }
+              }
+          }
+      
+          # Cleanup unused fields
+          mutate {
+              remove_field => "time"
+              remove_field => "timestamp"
+              remove_field => "received_from"
+              remove_field => "received_at"
+              remove_field => "syslog_message"
+              remove_field => "syslog_severity_code"
+              remove_field => "syslog_facility_code"
+              remove_field => "syslog_facility"
+              remove_field => "syslog_severity"
+              remove_field => "syslog_pri"
+              remove_field => "syslog_program"
+              remove_field => "syslog_pid"
+              remove_field => "syslog_hostname"
+              remove_field => "syslog_timestamp"
+          }
+      
+          #Route to index and type
+          mutate {
+              replace => { "[@metadata][index]" => "app" }
+              replace => { "[@metadata][type]" => "%{[event_type]}" }
+              remove_field => "[event_type]"
+              add_tag => [ 'firehose' ]
+          }
+      
+      }
+      
+        if "firehose" in [tags] {
+          # Parse messages from /v2/events api logged by https://github.com/stayup-io/cf-app-events-logger
+      
+      if [@message] =~ /.*"event_type":"AppEvent".*/  {
+      
+          json {
+              source => "[@message]"
+              target => "[app_event]"
+              add_tag => "app_event"
+          }
+      
+          date {
+              match => [ "[app_event][timestamp]", "ISO8601" ]
+          }
+      
+          ruby {
+              code => "event['@metadata']['app_event_metadata_as_string'] = event['app_event']['metadata'].to_s"
+          }
+          mutate {
+              replace => { "[@message]" => "%{[app_event][type]} %{[@metadata][app_event_metadata_as_string]}" }
+          }
+      
+          mutate {
+              replace => { "[@source][component]" => "AppEvent" }
+              replace => { "[@source][instance]" => "0" }
+              convert => { "[@source][instance]" => "integer" }
+              replace => { "[@source][name]" => "AppEvent/0" }
+      
+              replace => { "[@source][app][id]" => "%{[app_event][app_id]}" }
+              replace => { "[@source][app][name]" => "%{[app_event][app_name]}" }
+              replace => { "[@source][space][id]" => "%{[app_event][space_guid]}" }
+              replace => { "[@source][space][name]" => "%{[app_event][space_name]}" }
+              replace => { "[@source][org][id]" => "%{[app_event][organization_guid]}" }
+              replace => { "[@source][org][name]" => "%{[app_event][organization_name]}" }
+      
+              replace => { "[@metadata][type]" => "app_event" }
+      
+              remove_field => [ "[@source][message_type]", "[@source][origin]", "[@source][host]" ]
+          }
+      
+      }
+      
+      
+        }
+      } else if [@metadata][type] in ["syslog", "relp"] and [@source.host] == "loggregator" {
+      # Parse Cloud Foundry logs from loggregator (syslog)
+      # see https://github.com/cloudfoundry/loggregator/blob/master/src/loggregator/sinks/syslogwriter/syslog_writer.go#L156
+      
+      mutate {
+          add_field => [ "tmp_syslog_procid" ,"%{syslog_procid}" ]
+      }
+      
+      # [App/0] => [App, 0]
+      mutate {
+          gsub => [ "tmp_syslog_procid", "[\[\]]", "" ]
+          split => [ "tmp_syslog_procid", "/" ]
+          add_field => [ "source_type" ,"%{[tmp_syslog_procid][0]}"  ]
+          add_field => [ "source_instance" ,"%{[tmp_syslog_procid][1]}"  ]
+          remove_field => [ "tmp_syslog_procid" ]
+      }
+      
+      # For source types with no instance number, remove the field
+      if [source_instance] == "%{[tmp_syslog_procid][1]}" {
+          mutate {
+            remove_field => [ "source_instance" ]
+          }
+      }
+      
+      #If it looks like JSON, it must be JSON...
+      if [syslog_message] =~ /^\s*{".*}\s*$/ {
+          json {
+              source => "syslog_message"
+          }
+           # @todo seems like some messages have @timestamp in them? seems ci-specific
+          date {
+              match => [ "@timestamp", "ISO8601" ]
+          }
+      } else {
+          mutate {
+              add_field => [ "message", "%{syslog_message}" ]
+          }
+          if [message] == "-" {
+              mutate {
+                  remove_field => "message"
+              }
+          }
+      }
+       mutate {
+          rename => [ "syslog_program", "@source.app_id" ]
+      }
+       mutate {
+          add_tag => "cloudfoundry_loggregator"
+          remove_field => "syslog_facility"
+          remove_field => "syslog_facility_code"
+          remove_field => "syslog_message"
+          remove_field => "syslog_severity"
+          remove_field => "syslog_severity_code"
+          remove_field => "syslog5424_ver"
+          remove_field => "syslog6587_msglen"
+      }
+      
+      } else if [@metadata][type] in ["syslog", "relp"] and [syslog_program] == "vcap.uaa" {
+      grok {
+          match => { "syslog_message" =>
+          "\[job=%{NOTSPACE:jobname}%{SPACE}index=%{NOTSPACE:jobindex}\]%{SPACE}\[%{TIMESTAMP_ISO8601:uaa_timestamp}\]%{SPACE}uaa%{SPACE}-%{SPACE}%{NUMBER:pid:int}%{SPACE}\[%{DATA:thread_name}\]%{SPACE}....%{SPACE}%{LOGLEVEL:loglevel}%{SPACE}---%{SPACE}Audit:%{SPACE}%{WORD:audit_event_type}%{SPACE}\('%{DATA:audit_event_data}'\):%{SPACE}principal=%{DATA:audit_event_principal},%{SPACE}origin=\[%{DATA:audit_event_origin}\],%{SPACE}identityZoneId=\[%{DATA:audit_event_identity_zone_id}\]"
+          }
+          tag_on_failure => [
+              "fail/cloudfoundry/uaa-audit"
+          ]
+          add_tag => "uaa-audit"
+      }
+      
+      if !("fail/cloudfoundry/uaa-audit" in [tags]) {
+          date {
+              match => [ "uaa_timestamp", "ISO8601" ]
+              remove_field => "uaa_timestamp"
+          }
+      
+          if "PrincipalAuthenticationFailure" == [audit_event_type] {
+              mutate {
+                  add_field => { "audit_event_remote_address" => "%{audit_event_origin}" }
+             }
+          }
+      
+          if [audit_event_origin] =~ /remoteAddress=/ {
+              grok {
+                  match => { "audit_event_origin" => "remoteAddress=%{IP:audit_event_remote_address}" }
+              }
+          }
+      
+          if [audit_event_remote_address] {
+             geoip {
+                source => "audit_event_remote_address"
+             }
+          }
+      
+          mutate {
+              remove_field => "syslog_pri"
+              remove_field => "syslog_facility"
+              remove_field => "syslog_facility_code"
+              remove_field => "syslog_message"
+              remove_field => "syslog_severity"
+              remove_field => "syslog_severity_code"
+              remove_field => "syslog_program"
+              remove_field => "syslog_timestamp"
+              remove_field => "syslog_hostname"
+      
+              split =>  { "audit_event_origin" => ", " }
+      
+              add_field => { "[@source][component]" => "UAA" }
+              add_field => { "[@source][name]" => "%{jobname}/%{jobindex}" }
+              convert => { "jobindex" => "integer" }
+          }
+      
+          mutate {
+              remove_field => "jobname"
+              rename => { "jobindex"       => "[@source][instance]" }
+              rename => { "loglevel"       => "[@level]" }
+      
+              rename => { "pid"            => "[UAA][pid]" }
+              rename => { "thread_name"     => "[UAA][thread_name]" }
+      
+              rename => { "audit_event_type"              => "[UAA][type]" }
+              rename => { "audit_event_remote_address"    => "[UAA][remote_address]" }
+              rename => { "audit_event_data"              => "[UAA][data]" }
+              rename => { "audit_event_principal"         => "[UAA][principal]" }
+              rename => { "audit_event_origin"            => "[UAA][origin]" }
+              rename => { "audit_event_identity_zone_id"  => "[UAA][identity_zone_id]" }
+          }
+      
+          #Route to index and type
+          mutate {
+              replace => { "[@metadata][index]" => "platform" }
+              replace => { "[@metadata][type]" => "uaa-audit" }
+              add_tag => "uaa"
+              add_tag => "audit"
+          }
+      }
+      
+      
+      } else if "collector" in [tags] {
+      # Parse Cloud Foundry Collector
+      
+      mutate {
+          add_field => { "[@source][component]" => "%{[attributes][job]}" }
+          add_field => { "[@source][instance]" => "%{[attributes][index]}" }
+          add_field => { "[@source][deployment]" => "%{[attributes][deployment]}" }
+          add_field => { "[@source][host]" => "%{[attributes][ip]}" }
+          remove_field => [ "[attributes]" ]
+      }
+      
+      mutate {
+          add_field => { "[@source][name]" => "%{[@source][component]}/%{[@source][instance]}" }
+      }
+      
+      mutate {
+          rename => { "[key]" => "[metric][key]" }
+          convert => { "[value]" => "string" }
+      }
+      
+      if [value] =~ /^[-+]?\d{1,19}$/ {
+          mutate {
+              rename => { "[value]" => "[metric][value_int]" }
+              convert => { "[metric][value_int]" => "integer" }
+          }
+      } else {
+          mutate {
+              rename => { "[value]" => "[metric][value_float]" }
+              convert => { "[metric][value_float]" => "float" }
+          }
+      }
+      
+      mutate {
+          remove_field => [ "level", "facility", "file", "line", "version", "source_host", "host" ]
+      }
+      
+      #Route to index and type
+      mutate {
+          replace => { "[@metadata][index]" => "platform" }
+          replace => { "[@metadata][type]" => "metric" }
+          add_tag => "metric"
+      }
+      
+      } else if [@metadata][type] in ["syslog", "relp"] and [syslog_program] =~ /vcap\..*/ {
+      # Parse Cloud Foundry logs from syslog_aggregator
+      
+      grok {
+          match => { "syslog_message" => "(?:\[job=%{NOTSPACE:[@job][name]}|-) +(?:index=%{NOTSPACE:[@job][index]}\]|-) %{GREEDYDATA:_message_json}" }
+          tag_on_failure => [
+              "_grokparsefailure-cf-vcap"
+          ]
+      }
+      
+      if !("_grokparsefailure-cf-vcap" in [tags]) {
+          kv {
+              source => "msgdata"
+              field_split => " "
+              target => "msgdata"
+          }
+      
+          json {
+              source => "_message_json"
+              remove_field => "_message_json"
+          }
+      
+          mutate {
+              rename => [ "syslog_program", "[@shipper][name]" ]
+              replace => [ "[@job][host]", "%{[@source][host]}" ]
+              gsub => [
+                  "[@shipper][name]", "\.", "_",
+                  "[@job][name]", "\.", "_"
+                ]
+          }
+      
+          if [source] == "NatsStreamForwarder" {
+              json {
+                  source => "[data][nats_message]"
+                  target => "nats_message"
+              }
+      
+              mutate {
+                  remove_field => "[data][nats_message]"
+              }
+          }
+      
+          mutate {
+              add_tag => "cloudfoundry_vcap"
+              replace => [ "[@shipper][priority]", "%{syslog_pri}" ]
+              replace => [ "[@shipper][name]", "%{[@shipper][name]}_%{[@metadata][type]}" ]
+          }
+      
+          mutate {
+              remove_field => "syslog_facility"
+              remove_field => "syslog_facility_code"
+              remove_field => "syslog_message"
+              remove_field => "syslog_severity"
+              remove_field => "syslog_severity_code"
+          }
+      
+          mutate {
+              #replace => { "[@metadata][index]" => "platform" }
+              replace => { "[@metadata][type]" => "%{[@metadata][type]}_cf" }
+          }
+      }
+      
+      }
+      
+      #Cleanup
+      mutate {
+        rename => { "[tags]" => "[@tags]" }
+        remove_field => [ "@version" ]
+        remove_field => "@type"
+      }
   elasticsearch_config:
     <<: (( merge ))
     templates:
-      - logsearch-for-cloudfoundry: "{\n  \"template\" : \"logs-*\",\n  \"order\": 50,\n  \"settings\" : {\n    \"index\" : {\n      \"codec\": \"best_compression\",\n      \"search\" : {\n        \"slowlog\" : {\n          \"threshold\" : {\n            \"query\" : {\n              \"warn\" : \"30s\",\n              \"info\" : \"15s\",\n              \"debug\" : \"10s\",\n              \"trace\" : \"5s\"\n            }\n          }\n        }\n      },\n      \"query\" : { \"default_field\" : \"@message\" }\n    }\n  },\n  \"mappings\" : {\n    \"_default_\" : {\n       \"_all\" : {\"enabled\" : false},\n       \"dynamic_templates\" : [ {\n         \"message_field\" : {\n           \"match\" : \"message\",\n           \"match_mapping_type\" : \"string\",\n           \"mapping\" : {\n             \"type\" : \"string\", \"index\" : \"analyzed\", \"omit_norms\" : true\n           }\n         }\n       }, {\n         \"string_fields\" : {\n           \"match\" : \"*\",\n           \"match_mapping_type\" : \"string\",\n           \"mapping\" : {\n             \"type\" : \"string\", \n             \"index\" : \"not_analyzed\", \n             \"omit_norms\" : true\n           }\n         }\n       } ],\n       \"properties\" : {\n         \"@version\": { \"type\": \"string\", \"index\": \"not_analyzed\" },\n         \"@message\" : {\n            \"type\" : \"string\",\n            \"index\" : \"analyzed\",\n            \"norms\" : { \"enabled\" : false }\n         },\n         \"geoip\"  : {\n           \"type\" : \"object\",\n             \"dynamic\": true,\n             \"properties\" : {\n               \"location\" : { \"type\" : \"geo_point\" }\n             }\n         }\n       }\n    }\n  }\n}\n\n" 
+      - logsearch-for-cloudfoundry: |
+          {
+            "template" : "logs-*",
+            "order": 50,
+            "settings" : {
+              "index" : {
+                "codec": "best_compression",
+                "search" : {
+                  "slowlog" : {
+                    "threshold" : {
+                      "query" : {
+                        "warn" : "30s",
+                        "info" : "15s",
+                        "debug" : "10s",
+                        "trace" : "5s"
+                      }
+                    }
+                  }
+                },
+                "query" : { "default_field" : "@message" }
+              }
+            },
+            "mappings" : {
+              "_default_" : {
+                 "_all" : {"enabled" : false},
+                 "dynamic_templates" : [ {
+                   "message_field" : {
+                     "match" : "message",
+                     "match_mapping_type" : "string",
+                     "mapping" : {
+                       "type" : "string", "index" : "analyzed", "omit_norms" : true
+                     }
+                   }
+                 }, {
+                   "string_fields" : {
+                     "match" : "*",
+                     "match_mapping_type" : "string",
+                     "mapping" : {
+                       "type" : "string",
+                       "index" : "not_analyzed",
+                       "omit_norms" : true
+                     }
+                   }
+                 } ],
+                 "properties" : {
+                   "@version": { "type": "string", "index": "not_analyzed" },
+                   "@message" : {
+                      "type" : "string",
+                      "index" : "analyzed",
+                      "norms" : { "enabled" : false }
+                   },
+                   "geoip"  : {
+                     "type" : "object",
+                       "dynamic": true,
+                       "properties" : {
+                         "location" : { "type" : "geo_point" }
+                       }
+                   }
+                 }
+              }
+            }
+          }
+          


### PR DESCRIPTION
Having all the logstash-filters on one line was not particularly human-readable, so I split them out onto multiple lines. This is prep for adding more to the input and filters for the [AE]LB logs

Obviously comparing this by hand is a nightmare, so I'll lay out my methods for review:
1. deleted the `<<: (( merge ))` lines
2. loaded the YAML into python
3. printed the values of `root['properties']['logstash_parser']['filters']` and `root['properties']['elasticsearch_config']['templates'][0]['logsearch-for-cloudfoundry']
4. copied those values back into the original file
5. loaded the original file back in as a new dict
6. compared the values from the original dict and the new dict. The only differences were insignificant trailing spaces in the original that were not carried into the new version
7. added the `<<: (( merge ))` lines back in

