### PR TITLE
added links and credentials.

### DIFF
--- a/logsearch-jobs.yml
+++ b/logsearch-jobs.yml
@@ -350,11 +350,15 @@ instance_groups:
     release: logsearch-for-cloudfoundry
     consumes:
       elasticsearch: {from: elasticsearch_master}
+      cloud_controller: {from: cloud_controller}
     properties:
       cloudfoundry:
         firehose_events:
         - LogMessage
         - ContainerMetric
+        system_domain: (( grab $CF_SYSTEM_DOMAIN ))
+        user: (( grab $CF_USERNAME ))
+        password: (( grab $CF_PASSWORD ))
       kibana_objects:
         upload_patterns:
         - {type: index-pattern, pattern: "/var/vcap/jobs/upload-kibana-objects/kibana-objects/index-pattern/*.json"}


### PR DESCRIPTION
cloudfoundry-community/logsearch-for-cloudfoundry#319 introduced a
breaking change in the manifest, now the upload-kibana-objects job
needs a link to the cloud_controller, and authentication credentials to
kibana to upload the objects using the kibana object API.

//cc 18f/cg-private#5

Signed-off-by: Mike Lloyd <mike.lloyd@gsa.gov>