### PR TITLE
adding credentials in both deployments

### DIFF
--- a/logsearch-jobs.yml
+++ b/logsearch-jobs.yml
@@ -350,7 +350,6 @@ instance_groups:
     release: logsearch-for-cloudfoundry
     consumes:
       elasticsearch: {from: elasticsearch_master}
-      cloud_controller: {from: cloud_controller}
     properties:
       cloudfoundry:
         firehose_events:

--- a/logsearch-platform-jobs.yml
+++ b/logsearch-platform-jobs.yml
@@ -267,6 +267,10 @@ instance_groups:
     properties:
       elasticsearch_config:
         app_index_prefix: logs-platform
+      cloudfoundry:
+        system_domain: (( grab $CF_SYSTEM_DOMAIN ))
+        user: (( grab $CF_USERNAME ))
+        password: (( grab $CF_PASSWORD ))
       kibana_objects:
         upload_patterns:
         - {type: index-pattern, pattern: "/var/vcap/jobs/upload-kibana-objects/kibana-objects/index-pattern/*.json"}


### PR DESCRIPTION
removing cloud_controller link as it's optional and broke [the build](https://ci.fr.cloud.gov/teams/main/pipelines/deploy-logsearch/jobs/deploy-logsearch-development/builds/418) due to lack of deployment reference.

Signed-off-by: Mike Lloyd <mike.lloyd@gsa.gov>