### PR TITLE
[Don't merge] Add elb-log-ingestor to logsearch

### DIFF
--- a/logsearch-platform-jobs.yml
+++ b/logsearch-platform-jobs.yml
@@ -222,6 +222,26 @@ instance_groups:
         - /var/vcap/jobs/parser-config-lfc/config/deployment_lookup.yml
   - name: parser-config-lfc
     release: logsearch-for-cloudfoundry
+  - name:  elb-log-ingestor
+    release: elb-log-ingestor
+    consumes:
+      elasticsearch: {from: elasticsearch_master}
+    properties:
+        env:
+          # set in S3 creds
+          # AWS_ACCESS_KEY_ID: 
+          # AWS_SECRET_ACCESS_KEY:
+          # AWS_DEFAULT_REGION: 
+
+          ELB_INGESTOR_BUCKET: "(( grab terraform_outputs.elb_log_bucket ))"
+
+          ELB_INGESTOR_DONE_PREFIX: "(( grab terraform.stack_description ))-done"
+          ELB_INGESTOR_SEARCH_PREFIX: "(( grab terraform.stack_description ))"
+          ELB_INGESTOR_WORKING_PREFIX:  "(( grab terraform.stack_description ))-working"
+
+          ELB_INGESTOR_ELASTICSEARCH_HOSTS: localhost:9200
+          ELB_INGESTOR_INDEX_PATTERN: "logs-platform-%{+YYYY.MM.dd}"
+
   vm_type: logsearch_ingestor
   vm_extensions: [platform-syslog-lb]
   persistent_disk_type: logsearch_ingestor
@@ -231,7 +251,7 @@ instance_groups:
   - name: services
 
 ###########################
-#3nd deploy group - errands
+#3rd deploy group - errands
 ###########################
 - name: smoke-tests
   instances: 1


### PR DESCRIPTION
This adds the elb-log-ingestor to logstash-platform

open questions I have:
- should this thing instead go on its own VM, or is there a way to put it on only one instance of the ingestor VM? we probably only need one instance running this, and while it should tolerate having 3 instances running, there's no coordination in the tool to make that particularly efficient