### PR TITLE
Deployment fixing

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -1424,12 +1424,12 @@ resources:
 - name: tests-timer
   type: time
   source:
-    interval: 10m
+    interval: 30m
 
 - name: check-backup-timer
   type: time
   source:
-    interval: 10m
+    interval: 30m
 
 - name: terraform-yaml-development
   type: s3-iam

--- a/ci/smoke-tests-login.py
+++ b/ci/smoke-tests-login.py
@@ -23,5 +23,5 @@ if __name__ == "__main__":
         },
     )
     print(login.url, login.status_code)
-    assert login.url == 'https://logs.{}/'.format(os.environ['CF_SYSTEM_DOMAIN'])
+    assert login.url == 'https://logs.{}/app/kibana'.format(os.environ['CF_SYSTEM_DOMAIN'])
     assert login.status_code == 200

--- a/logsearch-jobs.yml
+++ b/logsearch-jobs.yml
@@ -65,6 +65,7 @@ instance_groups:
 
 - name: maintenance
   instances: 1
+  vm_extensions: [errand-profile]
   jobs:
   - name: elasticsearch
     release: logsearch
@@ -104,6 +105,25 @@ instance_groups:
         es:
           uri: http://localhost:9200
           all: true
+  - name: upload-kibana-objects
+    release: logsearch-for-cloudfoundry
+    consumes:
+      elasticsearch: {from: elasticsearch_master}
+    properties:
+      cloudfoundry:
+        firehose_events:
+        - LogMessage
+        - ContainerMetric
+        system_domain: (( grab $CF_SYSTEM_DOMAIN ))
+        user: (( grab $CF_USERNAME ))
+        password: (( grab $CF_PASSWORD ))
+      kibana_objects:
+        upload_patterns:
+        - {type: index-pattern, pattern: "/var/vcap/jobs/upload-kibana-objects/kibana-objects/index-pattern/*.json"}
+        - {type: config, pattern: "/var/vcap/jobs/upload-kibana-objects/kibana-objects/config/*.json"}
+        - {type: search, pattern: "/var/vcap/jobs/upload-kibana-objects/kibana-objects/search/app-*.json"}
+        - {type: visualization, pattern: "/var/vcap/jobs/upload-kibana-objects/kibana-objects/visualization/App-*.json"}
+        - {type: dashboard, pattern: "/var/vcap/jobs/upload-kibana-objects/kibana-objects/dashboard/App-*.json"}
   # TODO: Drop after https://github.com/cloudfoundry-community/logsearch-for-cloudfoundry/pull/267 is merged
   - name: cron
     release: cron
@@ -336,34 +356,3 @@ instance_groups:
     release: logsearch
     consumes:
       elasticsearch: {from: elasticsearch_master}
-
-- name: upload-kibana-objects
-  instances: 1
-  vm_type: errand_small
-  vm_extensions: [errand-profile]
-  stemcell: default
-  azs: [z1]
-  networks:
-  - name: services
-  lifecycle: errand
-  release: logsearch-for-cloudfoundry
-  jobs:
-  - name: upload-kibana-objects
-    release: logsearch-for-cloudfoundry
-    consumes:
-      elasticsearch: {from: elasticsearch_master}
-    properties:
-      cloudfoundry:
-        firehose_events:
-        - LogMessage
-        - ContainerMetric
-        system_domain: (( grab $CF_SYSTEM_DOMAIN ))
-        user: (( grab $CF_USERNAME ))
-        password: (( grab $CF_PASSWORD ))
-      kibana_objects:
-        upload_patterns:
-        - {type: index-pattern, pattern: "/var/vcap/jobs/upload-kibana-objects/kibana-objects/index-pattern/*.json"}
-        - {type: config, pattern: "/var/vcap/jobs/upload-kibana-objects/kibana-objects/config/*.json"}
-        - {type: search, pattern: "/var/vcap/jobs/upload-kibana-objects/kibana-objects/search/app-*.json"}
-        - {type: visualization, pattern: "/var/vcap/jobs/upload-kibana-objects/kibana-objects/visualization/App-*.json"}
-        - {type: dashboard, pattern: "/var/vcap/jobs/upload-kibana-objects/kibana-objects/dashboard/App-*.json"}

--- a/logsearch-jobs.yml
+++ b/logsearch-jobs.yml
@@ -175,7 +175,6 @@ instance_groups:
           fd: 131072  # 2 ** 17
         health:
           timeout: 900
-          disable_post_start: true
         recovery:
           delay_allocation_restart: "15m"
         migrate_data_path: true

--- a/logsearch-jobs.yml
+++ b/logsearch-jobs.yml
@@ -279,6 +279,8 @@ instance_groups:
         heap_size: 1G
   - name: ingestor_syslog
     release: logsearch
+    consumes:
+      elasticsearch: nil
     properties:
       logstash:
         queue:

--- a/logsearch-jobs.yml
+++ b/logsearch-jobs.yml
@@ -311,6 +311,7 @@ instance_groups:
       logstash:
         queue:
           max_bytes: 30gb
+          data_hosts: [127.0.0.1]
       logstash_parser:
         elasticsearch:
           # Use per-day indexing strategy

--- a/logsearch-jobs.yml
+++ b/logsearch-jobs.yml
@@ -197,6 +197,7 @@ instance_groups:
     properties:
       elasticsearch:
         heap_size: 2G
+        migrate_data_path: true
   - name: kibana
     release: logsearch
     consumes:

--- a/logsearch-jobs.yml
+++ b/logsearch-jobs.yml
@@ -311,12 +311,12 @@ instance_groups:
       logstash:
         queue:
           max_bytes: 30gb
-          data_hosts: [127.0.0.1]
       logstash_parser:
         elasticsearch:
           # Use per-day indexing strategy
           index: "logs-app-%{+YYYY.MM.dd}"
           index_type: "%{@type}"
+          data_hosts: [127.0.0.1]
         filters:
         - logsearch-for-cf: /var/vcap/packages/logsearch-config-logstash-filters/logstash-filters-default.conf
         deployment_dictionary:

--- a/logsearch-jobs.yml
+++ b/logsearch-jobs.yml
@@ -280,7 +280,7 @@ instance_groups:
   - name: ingestor_syslog
     release: logsearch
     consumes:
-      elasticsearch: nil
+      elasticsearch: {from: elasticsearch_master}
     properties:
       logstash:
         queue:

--- a/logsearch-jobs.yml
+++ b/logsearch-jobs.yml
@@ -14,6 +14,7 @@ instance_groups:
     properties:
       elasticsearch:
         cluster_name: logsearch
+        migrate_data_path: true
         node:
           allow_master: true
           allow_data: false
@@ -74,6 +75,7 @@ instance_groups:
     properties:
       elasticsearch:
         heap_size: 2G
+        migrate_data_path: true
   - name: curator
     release: logsearch
     # nil the link and use the colocated instance when https://github.com/cloudfoundry-community/logsearch-boshrelease/pull/90 is merged
@@ -175,6 +177,7 @@ instance_groups:
           timeout: 900
         recovery:
           delay_allocation_restart: "15m"
+        migrate_data_path: true
   vm_type: logsearch_es_data
   persistent_disk_type: logsearch_es_data
   stemcell: default

--- a/logsearch-jobs.yml
+++ b/logsearch-jobs.yml
@@ -175,6 +175,7 @@ instance_groups:
           fd: 131072  # 2 ** 17
         health:
           timeout: 900
+          disable_post_start: true
         recovery:
           delay_allocation_restart: "15m"
         migrate_data_path: true

--- a/logsearch-jobs.yml
+++ b/logsearch-jobs.yml
@@ -204,7 +204,7 @@ instance_groups:
         default_app_id: "dashboard/App-Overview"
         plugins:
         - auth: /var/vcap/packages/kibana-auth-plugin/kibana-auth-plugin.zip
-        config_options: |-
+        config_options: 
           console.enabled: false
         env:
         - NODE_ENV: production

--- a/logsearch-jobs.yml
+++ b/logsearch-jobs.yml
@@ -250,6 +250,7 @@ instance_groups:
     properties:
       elasticsearch:
         heap_size: 1G
+        migrate_data_path: true
   - name: archiver_syslog
     release: logsearch
     properties:
@@ -300,6 +301,7 @@ instance_groups:
     properties:
       elasticsearch:
         heap_size: 1G
+        migrate_data_path: true
   - name: ingestor_syslog
     release: logsearch
     consumes:

--- a/logsearch-platform-deployment.yml
+++ b/logsearch-platform-deployment.yml
@@ -2,10 +2,10 @@ director_uuid: (( param "Please set the UUID of your BOSH Director" ))
 
 update:
   serial: false
-  canaries: 2
+  canaries: 1
   canary_watch_time: 30000-600000
   update_watch_time: 5000-600000
-  max_in_flight: 2
+  max_in_flight: 1
   max_errors: 1
 
 stemcells:

--- a/logsearch-platform-deployment.yml
+++ b/logsearch-platform-deployment.yml
@@ -2,10 +2,10 @@ director_uuid: (( param "Please set the UUID of your BOSH Director" ))
 
 update:
   serial: false
-  canaries: 1
+  canaries: 2
   canary_watch_time: 30000-600000
   update_watch_time: 5000-600000
-  max_in_flight: 1
+  max_in_flight: 2
   max_errors: 1
 
 stemcells:

--- a/logsearch-platform-development.yml
+++ b/logsearch-platform-development.yml
@@ -7,9 +7,6 @@ instance_groups:
     - (( replace ))
     - (( grab terraform_outputs.logsearch_static_ips.[7]))
 
-- name: elasticsearch_data
-  instances: 3
-
 - name: ingestor
   instances: 1
 

--- a/logsearch-platform-jobs.yml
+++ b/logsearch-platform-jobs.yml
@@ -53,6 +53,7 @@ instance_groups:
 
 - name: maintenance
   instances: 1
+  vm_extensions: [errand-profile]
   jobs:
   - name: elasticsearch
     release: logsearch

--- a/logsearch-platform-jobs.yml
+++ b/logsearch-platform-jobs.yml
@@ -101,6 +101,9 @@ instance_groups:
     consumes:
       elasticsearch: {from: elasticsearch_master}
     properties:
+      kibana_objects:
+        login_host_name: opslogin
+        host_name: logs-platform
       elasticsearch_config:
         app_index_prefix: logs-platform
       cloudfoundry:

--- a/logsearch-platform-jobs.yml
+++ b/logsearch-platform-jobs.yml
@@ -109,7 +109,7 @@ instance_groups:
         password: (( grab $CF_PASSWORD ))
       kibana_objects:
         host_name: logs-platform
-        login_host_name: opslogin
+        login_fqdn: opslogin.fr.cloud.gov
         upload_patterns:
         - {type: index-pattern, pattern: "/var/vcap/jobs/upload-kibana-objects/kibana-objects/index-pattern/*.json"}
         - {type: config, pattern: "/var/vcap/jobs/upload-kibana-objects/kibana-objects/config/*.json"}

--- a/logsearch-platform-jobs.yml
+++ b/logsearch-platform-jobs.yml
@@ -101,9 +101,6 @@ instance_groups:
     consumes:
       elasticsearch: {from: elasticsearch_master}
     properties:
-      kibana_objects:
-        login_host_name: opslogin
-        host_name: logs-platform
       elasticsearch_config:
         app_index_prefix: logs-platform
       cloudfoundry:
@@ -111,6 +108,8 @@ instance_groups:
         user: (( grab $CF_USERNAME ))
         password: (( grab $CF_PASSWORD ))
       kibana_objects:
+        host_name: logs-platform
+        login_host_name: opslogin
         upload_patterns:
         - {type: index-pattern, pattern: "/var/vcap/jobs/upload-kibana-objects/kibana-objects/index-pattern/*.json"}
         - {type: config, pattern: "/var/vcap/jobs/upload-kibana-objects/kibana-objects/config/*.json"}

--- a/logsearch-platform-jobs.yml
+++ b/logsearch-platform-jobs.yml
@@ -96,24 +96,24 @@ instance_groups:
         es:
           uri: http://localhost:9200
           all: true
-  #- name: upload-kibana-objects
-  #  release: logsearch-for-cloudfoundry
-  #  consumes:
-  #    elasticsearch: {from: elasticsearch_master}
-  #  properties:
-  #    elasticsearch_config:
-  #      app_index_prefix: logs-platform
-  #    cloudfoundry:
-  #      system_domain: (( grab $CF_SYSTEM_DOMAIN ))
-  #      user: (( grab $CF_USERNAME ))
-  #      password: (( grab $CF_PASSWORD ))
-  #    kibana_objects:
-  #      upload_patterns:
-  #      - {type: index-pattern, pattern: "/var/vcap/jobs/upload-kibana-objects/kibana-objects/index-pattern/*.json"}
-  #      - {type: config, pattern: "/var/vcap/jobs/upload-kibana-objects/kibana-objects/config/*.json"}
-  #      - {type: search, pattern: "/var/vcap/jobs/upload-kibana-objects/kibana-objects/search/platform-*.json"}
-  #      - {type: visualization, pattern: "/var/vcap/jobs/upload-kibana-objects/kibana-objects/visualization/Platform-*.json"}
-  #      - {type: dashboard, pattern: "/var/vcap/jobs/upload-kibana-objects/kibana-objects/dashboard/Platform-*.json"}
+  - name: upload-kibana-objects
+    release: logsearch-for-cloudfoundry
+    consumes:
+      elasticsearch: {from: elasticsearch_master}
+    properties:
+      elasticsearch_config:
+        app_index_prefix: logs-platform
+      cloudfoundry:
+        system_domain: (( grab $CF_SYSTEM_DOMAIN ))
+        user: (( grab $CF_USERNAME ))
+        password: (( grab $CF_PASSWORD ))
+      kibana_objects:
+        upload_patterns:
+        - {type: index-pattern, pattern: "/var/vcap/jobs/upload-kibana-objects/kibana-objects/index-pattern/*.json"}
+        - {type: config, pattern: "/var/vcap/jobs/upload-kibana-objects/kibana-objects/config/*.json"}
+        - {type: search, pattern: "/var/vcap/jobs/upload-kibana-objects/kibana-objects/search/platform-*.json"}
+        - {type: visualization, pattern: "/var/vcap/jobs/upload-kibana-objects/kibana-objects/visualization/Platform-*.json"}
+        - {type: dashboard, pattern: "/var/vcap/jobs/upload-kibana-objects/kibana-objects/dashboard/Platform-*.json"}
   vm_type: logsearch_maintenance
   stemcell: default
   azs: [z1]

--- a/logsearch-platform-jobs.yml
+++ b/logsearch-platform-jobs.yml
@@ -96,24 +96,24 @@ instance_groups:
         es:
           uri: http://localhost:9200
           all: true
-  - name: upload-kibana-objects
-    release: logsearch-for-cloudfoundry
-    consumes:
-      elasticsearch: {from: elasticsearch_master}
-    properties:
-      elasticsearch_config:
-        app_index_prefix: logs-platform
-      cloudfoundry:
-        system_domain: (( grab $CF_SYSTEM_DOMAIN ))
-        user: (( grab $CF_USERNAME ))
-        password: (( grab $CF_PASSWORD ))
-      kibana_objects:
-        upload_patterns:
-        - {type: index-pattern, pattern: "/var/vcap/jobs/upload-kibana-objects/kibana-objects/index-pattern/*.json"}
-        - {type: config, pattern: "/var/vcap/jobs/upload-kibana-objects/kibana-objects/config/*.json"}
-        - {type: search, pattern: "/var/vcap/jobs/upload-kibana-objects/kibana-objects/search/platform-*.json"}
-        - {type: visualization, pattern: "/var/vcap/jobs/upload-kibana-objects/kibana-objects/visualization/Platform-*.json"}
-        - {type: dashboard, pattern: "/var/vcap/jobs/upload-kibana-objects/kibana-objects/dashboard/Platform-*.json"}
+  #- name: upload-kibana-objects
+  #  release: logsearch-for-cloudfoundry
+  #  consumes:
+  #    elasticsearch: {from: elasticsearch_master}
+  #  properties:
+  #    elasticsearch_config:
+  #      app_index_prefix: logs-platform
+  #    cloudfoundry:
+  #      system_domain: (( grab $CF_SYSTEM_DOMAIN ))
+  #      user: (( grab $CF_USERNAME ))
+  #      password: (( grab $CF_PASSWORD ))
+  #    kibana_objects:
+  #      upload_patterns:
+  #      - {type: index-pattern, pattern: "/var/vcap/jobs/upload-kibana-objects/kibana-objects/index-pattern/*.json"}
+  #      - {type: config, pattern: "/var/vcap/jobs/upload-kibana-objects/kibana-objects/config/*.json"}
+  #      - {type: search, pattern: "/var/vcap/jobs/upload-kibana-objects/kibana-objects/search/platform-*.json"}
+  #      - {type: visualization, pattern: "/var/vcap/jobs/upload-kibana-objects/kibana-objects/visualization/Platform-*.json"}
+  #      - {type: dashboard, pattern: "/var/vcap/jobs/upload-kibana-objects/kibana-objects/dashboard/Platform-*.json"}
   vm_type: logsearch_maintenance
   stemcell: default
   azs: [z1]

--- a/logsearch-platform-jobs.yml
+++ b/logsearch-platform-jobs.yml
@@ -224,6 +224,7 @@ instance_groups:
           # Use per-day indexing strategy
           index: "logs-platform-%{+YYYY.MM.dd}"
           index_type: "%{@type}"
+          data_hosts: [127.0.0.1]
         filters:
         - path: /var/vcap/packages/logsearch-config-logstash-filters/logstash-filters-default.conf
         - content: |

--- a/logsearch-platform-jobs.yml
+++ b/logsearch-platform-jobs.yml
@@ -26,6 +26,7 @@ instance_groups:
           timeout: 900
         recovery:
           delay_allocation_restart: "15m"
+        config_options: {"xpack.monitoring.enabled": false}
   vm_type: logsearch_es_master
   persistent_disk_type: logsearch_es_master
   stemcell: default
@@ -60,6 +61,7 @@ instance_groups:
     properties:
       elasticsearch:
         heap_size: 2G
+        config_options: {"xpack.monitoring.enabled": false}
   - name: curator
     release: logsearch
     consumes:
@@ -123,6 +125,7 @@ instance_groups:
           timeout: 900
         recovery:
           delay_allocation_restart: "15m"
+        config_options: {"xpack.monitoring.enabled": false}
   vm_type: logsearch_es_data
   persistent_disk_type: logsearch_es_platform_data
   stemcell: default
@@ -189,6 +192,7 @@ instance_groups:
     properties:
       elasticsearch:
         heap_size: 1G
+        config_options: {"xpack.monitoring.enabled": false}
   - name: ingestor_syslog
     release: logsearch
     consumes: 

--- a/logsearch-platform-jobs.yml
+++ b/logsearch-platform-jobs.yml
@@ -27,6 +27,7 @@ instance_groups:
         recovery:
           delay_allocation_restart: "15m"
         config_options: {"xpack.monitoring.enabled": false}
+        migrate_data_path: true
   vm_type: logsearch_es_master
   persistent_disk_type: logsearch_es_master
   stemcell: default
@@ -145,6 +146,7 @@ instance_groups:
         recovery:
           delay_allocation_restart: "15m"
         config_options: {"xpack.monitoring.enabled": false}
+        migrate_data_path: true
   vm_type: logsearch_es_data
   persistent_disk_type: logsearch_es_platform_data
   stemcell: default
@@ -164,6 +166,7 @@ instance_groups:
     properties:
       elasticsearch:
         heap_size: 2G
+        migrate_data_path: true
   - name: kibana
     release: logsearch
     consumes:
@@ -212,6 +215,7 @@ instance_groups:
       elasticsearch:
         heap_size: 1G
         config_options: {"xpack.monitoring.enabled": false}
+        migrate_data_path: true
   - name: ingestor_syslog
     release: logsearch
     consumes: 

--- a/logsearch-platform-jobs.yml
+++ b/logsearch-platform-jobs.yml
@@ -123,7 +123,6 @@ instance_groups:
           fd: 131072  # 2 ** 17
         health:
           timeout: 900
-          disable_post_start: true
         recovery:
           delay_allocation_restart: "15m"
         config_options: {"xpack.monitoring.enabled": false}

--- a/logsearch-platform-jobs.yml
+++ b/logsearch-platform-jobs.yml
@@ -64,6 +64,7 @@ instance_groups:
       elasticsearch:
         heap_size: 2G
         config_options: {"xpack.monitoring.enabled": false}
+        migrate_data_path: true
   - name: curator
     release: logsearch
     consumes:

--- a/logsearch-platform-jobs.yml
+++ b/logsearch-platform-jobs.yml
@@ -191,6 +191,8 @@ instance_groups:
         heap_size: 1G
   - name: ingestor_syslog
     release: logsearch
+    consumes: 
+      elasticsearch: nil
     properties:
       logstash:
         queue:

--- a/logsearch-platform-jobs.yml
+++ b/logsearch-platform-jobs.yml
@@ -93,6 +93,24 @@ instance_groups:
         es:
           uri: http://localhost:9200
           all: true
+  - name: upload-kibana-objects
+    release: logsearch-for-cloudfoundry
+    consumes:
+      elasticsearch: {from: elasticsearch_master}
+    properties:
+      elasticsearch_config:
+        app_index_prefix: logs-platform
+      cloudfoundry:
+        system_domain: (( grab $CF_SYSTEM_DOMAIN ))
+        user: (( grab $CF_USERNAME ))
+        password: (( grab $CF_PASSWORD ))
+      kibana_objects:
+        upload_patterns:
+        - {type: index-pattern, pattern: "/var/vcap/jobs/upload-kibana-objects/kibana-objects/index-pattern/*.json"}
+        - {type: config, pattern: "/var/vcap/jobs/upload-kibana-objects/kibana-objects/config/*.json"}
+        - {type: search, pattern: "/var/vcap/jobs/upload-kibana-objects/kibana-objects/search/platform-*.json"}
+        - {type: visualization, pattern: "/var/vcap/jobs/upload-kibana-objects/kibana-objects/visualization/Platform-*.json"}
+        - {type: dashboard, pattern: "/var/vcap/jobs/upload-kibana-objects/kibana-objects/dashboard/Platform-*.json"}
   vm_type: logsearch_maintenance
   stemcell: default
   azs: [z1]
@@ -286,21 +304,3 @@ instance_groups:
   lifecycle: errand
   release: logsearch-for-cloudfoundry
   jobs:
-  - name: upload-kibana-objects
-    release: logsearch-for-cloudfoundry
-    consumes:
-      elasticsearch: {from: elasticsearch_master}
-    properties:
-      elasticsearch_config:
-        app_index_prefix: logs-platform
-      cloudfoundry:
-        system_domain: (( grab $CF_SYSTEM_DOMAIN ))
-        user: (( grab $CF_USERNAME ))
-        password: (( grab $CF_PASSWORD ))
-      kibana_objects:
-        upload_patterns:
-        - {type: index-pattern, pattern: "/var/vcap/jobs/upload-kibana-objects/kibana-objects/index-pattern/*.json"}
-        - {type: config, pattern: "/var/vcap/jobs/upload-kibana-objects/kibana-objects/config/*.json"}
-        - {type: search, pattern: "/var/vcap/jobs/upload-kibana-objects/kibana-objects/search/platform-*.json"}
-        - {type: visualization, pattern: "/var/vcap/jobs/upload-kibana-objects/kibana-objects/visualization/Platform-*.json"}
-        - {type: dashboard, pattern: "/var/vcap/jobs/upload-kibana-objects/kibana-objects/dashboard/Platform-*.json"}

--- a/logsearch-platform-jobs.yml
+++ b/logsearch-platform-jobs.yml
@@ -292,15 +292,3 @@ instance_groups:
     release: logsearch
     consumes:
       elasticsearch: {from: elasticsearch_master}
-
-- name: upload-kibana-objects
-  instances: 1
-  vm_type: errand_small
-  vm_extensions: [errand-profile]
-  stemcell: default
-  azs: [z1]
-  networks:
-  - name: services
-  lifecycle: errand
-  release: logsearch-for-cloudfoundry
-  jobs:

--- a/logsearch-platform-jobs.yml
+++ b/logsearch-platform-jobs.yml
@@ -192,7 +192,7 @@ instance_groups:
   - name: ingestor_syslog
     release: logsearch
     consumes: 
-      elasticsearch: nil
+      elasticsearch: {from: elasticsearch_master}
     properties:
       logstash:
         queue:

--- a/logsearch-platform-jobs.yml
+++ b/logsearch-platform-jobs.yml
@@ -123,6 +123,7 @@ instance_groups:
           fd: 131072  # 2 ** 17
         health:
           timeout: 900
+          disable_post_start: true
         recovery:
           delay_allocation_restart: "15m"
         config_options: {"xpack.monitoring.enabled": false}


### PR DESCRIPTION
highlights:
- move upload-kibana-objects job to the maintenance VM. That's where the reference deployment puts it, and it relies on colocation for its python dependencies
- scale dev up to 5 instances. This matches prod, and dev was running out of space after adding ELB logs (I don't anticipate the same issue in stage/development - in both cases, we have more than 10 Tb of space available)
- throttle smoke tests down to 30 minutes. while working on this, I noticed that smoke tests are frequently being queued while the last smoke test is still running. Having a smoke test always running is a PITA when working on the pipeline.
- specify what release to consume elasticsearch from - this is a reaction to an upstream change causing this error: `Failed to resolve link 'elasticsearch' with type 'elasticsearch' from job 'ingestor_syslog' in instance group 'ingestor'. Multiple link providers found:`