### PR TITLE
Scale platform

### DIFF
--- a/logsearch-platform-development.yml
+++ b/logsearch-platform-development.yml
@@ -24,8 +24,3 @@ instance_groups:
 
 - name: ingestor
   instances: 3
-  jobs:
-  - name: elasticsearch
-    properties:
-      elasticsearch:
-        heap_size: 1G

--- a/logsearch-platform-development.yml
+++ b/logsearch-platform-development.yml
@@ -21,3 +21,11 @@ instance_groups:
   - name: oauth2-proxy
     properties:
       redirect_url: https://logs-platform.dev.us-gov-west-1.aws-us-gov.cloud.gov/oauth2/callback
+
+- name: ingestor
+  instances: 3
+  jobs:
+  - name: elasticsearch
+    properties:
+      elasticsearch:
+        heap_size: 1G

--- a/logsearch-platform-jobs.yml
+++ b/logsearch-platform-jobs.yml
@@ -208,7 +208,7 @@ instance_groups:
   - name: services
 
 - name: ingestor
-  instances: 3
+  instances: 5
   jobs:
   - name: elasticsearch
     release: logsearch
@@ -216,7 +216,7 @@ instance_groups:
       elasticsearch: {from: elasticsearch_master}
     properties:
       elasticsearch:
-        heap_size: 1G
+        heap_size: 4G
         config_options: {"xpack.monitoring.enabled": false}
         migrate_data_path: true
   - name: ingestor_syslog

--- a/logsearch-platform-jobs.yml
+++ b/logsearch-platform-jobs.yml
@@ -216,7 +216,7 @@ instance_groups:
       elasticsearch: {from: elasticsearch_master}
     properties:
       elasticsearch:
-        heap_size: 4G
+        heap_size: 1G
         config_options: {"xpack.monitoring.enabled": false}
         migrate_data_path: true
   - name: ingestor_syslog


### PR DESCRIPTION
This increases the number of ingestors for logsearch-platform. Looking at [elasticsearch's docs on improving index performance](https://www.elastic.co/guide/en/elasticsearch/reference/master/tune-for-indexing-speed.html), they suggest adding workers until the cluster starts to show problems keeping up, and the cluster does not look at all unhappy right now (looking at CPU usage, GC times and counts)