### PR TITLE
scale data and ingestion nodes to handle arbitrary spikes in customer workloads

### DIFF
--- a/logsearch-jobs.yml
+++ b/logsearch-jobs.yml
@@ -157,7 +157,7 @@ instance_groups:
 #2nd deploy group - elasticsearch_data, kibana, ingestors
 #########################################################
 - name: elasticsearch_data
-  instances: 6
+  instances: 8
   jobs:
   - name: elasticsearch
     release: logsearch

--- a/logsearch-production.yml
+++ b/logsearch-production.yml
@@ -8,7 +8,7 @@ instance_groups:
         api_endpoint: https://api.fr.cloud.gov
 
 - name: ingestor
-  instances: 3
+  instances: 5
   jobs:
   - name: ingestor_cloudfoundry-firehose
     properties:


### PR DESCRIPTION
Bring the data nodes up to 8 and the ingestors up to 5.

### Security Considerations

None, just a scaling change.

Signed-off-by: Mike Lloyd <mike.lloyd@gsa.gov>