### PR TITLE
don't require logsearch-for-cloudfoundry release to pass platform environments 

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -182,9 +182,6 @@ jobs:
     - get: logsearch-release
       trigger: true
       passed: [deploy-logsearch-platform-development]
-    - get: logsearch-for-cloudfoundry-release
-      trigger: true
-      passed: [deploy-logsearch-platform-development]
     - get: logsearch-stemcell-xenial
       trigger: true
       passed: [deploy-logsearch-platform-development]
@@ -252,7 +249,6 @@ jobs:
       passed: [smoke-tests-platform-development]
     - get: logsearch-for-cloudfoundry-release
       trigger: true
-      passed: [smoke-tests-platform-development]
     - get: logsearch-release
       trigger: true
       passed: [smoke-tests-platform-development]
@@ -465,9 +461,6 @@ jobs:
     - get: logsearch-config
       trigger: true
       passed: [smoke-tests-development, smoke-tests-login-development]
-    - get: logsearch-for-cloudfoundry-release
-      trigger: true
-      passed: [smoke-tests-development, smoke-tests-login-development]
     - get: logsearch-release
       trigger: true
       passed: [smoke-tests-development, smoke-tests-login-development]
@@ -536,9 +529,6 @@ jobs:
       trigger: true
     - get: pipeline-tasks
     - get: logsearch-config
-      trigger: true
-      passed: [deploy-logsearch-platform-staging]
-    - get: logsearch-for-cloudfoundry-release
       trigger: true
       passed: [deploy-logsearch-platform-staging]
     - get: logsearch-release
@@ -621,7 +611,7 @@ jobs:
       passed: [smoke-tests-platform-staging]
     - get: logsearch-for-cloudfoundry-release
       trigger: true
-      passed: [smoke-tests-platform-staging]
+      passed: [smoke-tests-development, smoke-tests-login-development]
     - get: logsearch-release
       trigger: true
       passed: [smoke-tests-platform-staging]
@@ -826,9 +816,6 @@ jobs:
     - get: logsearch-config
       trigger: true
       passed: [smoke-tests-staging, smoke-tests-login-staging]
-    - get: logsearch-for-cloudfoundry-release
-      trigger: true
-      passed: [smoke-tests-staging, smoke-tests-login-staging]
     - get: logsearch-release
       trigger: true
       passed: [smoke-tests-staging, smoke-tests-login-staging]
@@ -897,9 +884,6 @@ jobs:
       trigger: true
     - get: pipeline-tasks
     - get: logsearch-config
-      trigger: true
-      passed: [deploy-logsearch-platform-production]
-    - get: logsearch-for-cloudfoundry-release
       trigger: true
       passed: [deploy-logsearch-platform-production]
     - get: logsearch-release
@@ -982,7 +966,7 @@ jobs:
       passed: [smoke-tests-platform-production]
     - get: logsearch-for-cloudfoundry-release
       trigger: true
-      passed: [smoke-tests-platform-production]
+      passed: [smoke-tests-staging, smoke-tests-login-staging]
     - get: logsearch-release
       trigger: true
       passed: [smoke-tests-platform-production]


### PR DESCRIPTION
# Security Considerations
none.