### PR TITLE
add logsearch-for-cloudfoundry back into platform deployments

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -182,6 +182,9 @@ jobs:
     - get: logsearch-release
       trigger: true
       passed: [deploy-logsearch-platform-development]
+    - get: logsearch-for-cloudfoundry-release
+      trigger: true
+      passed: [deploy-logsearch-platform-development]
     - get: logsearch-stemcell-xenial
       trigger: true
       passed: [deploy-logsearch-platform-development]
@@ -464,6 +467,9 @@ jobs:
     - get: logsearch-release
       trigger: true
       passed: [smoke-tests-development, smoke-tests-login-development]
+    - get: logsearch-for-cloudfoundry-release
+      trigger: true
+      passed: [smoke-tests-development, smoke-tests-login-development]
     - get: prometheus-release
       trigger: true
       passed: [smoke-tests-development, smoke-tests-login-development]
@@ -532,6 +538,9 @@ jobs:
       trigger: true
       passed: [deploy-logsearch-platform-staging]
     - get: logsearch-release
+      trigger: true
+      passed: [deploy-logsearch-platform-staging]
+    - get: logsearch-for-cloudfoundry-release
       trigger: true
       passed: [deploy-logsearch-platform-staging]
     - get: prometheus-release
@@ -819,6 +828,9 @@ jobs:
     - get: logsearch-release
       trigger: true
       passed: [smoke-tests-staging, smoke-tests-login-staging]
+    - get: logsearch-for-cloudfoundry-release
+      trigger: true
+      passed: [smoke-tests-staging, smoke-tests-login-staging]
     - get: prometheus-release
       trigger: true
       passed: [smoke-tests-staging, smoke-tests-login-staging]
@@ -887,6 +899,9 @@ jobs:
       trigger: true
       passed: [deploy-logsearch-platform-production]
     - get: logsearch-release
+      trigger: true
+      passed: [deploy-logsearch-platform-production]
+    - get: logsearch-for-cloudfoundry-release
       trigger: true
       passed: [deploy-logsearch-platform-production]
     - get: prometheus-release


### PR DESCRIPTION
Turns out these are needed for logsearch-platform

# Security Considerations
None