### PR TITLE
bump healthcheck timeout in production

### DIFF
--- a/logsearch-platform-production.yml
+++ b/logsearch-platform-production.yml
@@ -4,3 +4,11 @@ instance_groups:
   - name: oauth2-proxy
     properties:
       redirect_url: https://logs-platform.fr.cloud.gov/oauth2/callback
+- name: ingestor
+  jobs:
+  - name: ingestor_syslog
+    properties:
+      logstash_ingestor:
+        health:
+          timeout: 900
+


### PR DESCRIPTION
We scaled the ingestors last month, but we can't get the change out because they are failing their post-starts, presumably because they're overloaded. 

This gives them longer to run their post-starts, so hopefully we can scale

# Security Considerations
None