### PR TITLE
Moar nodes

### DIFF
--- a/logsearch-platform-development.yml
+++ b/logsearch-platform-development.yml
@@ -24,3 +24,7 @@ instance_groups:
 
 - name: ingestor
   instances: 3
+
+
+- name: elasticsearch_data
+  instances: 5

--- a/logsearch-platform-jobs.yml
+++ b/logsearch-platform-jobs.yml
@@ -128,7 +128,7 @@ instance_groups:
 #2nd deploy group - elasticsearch_data, kibana, ingestors
 #########################################################
 - name: elasticsearch_data
-  instances: 5
+  instances: 7
   jobs:
   - name: elasticsearch
     release: logsearch


### PR DESCRIPTION
This adds 2 more data nodes to the logsearch-platform deployment in production.
The *hope* is that this will improve ingestion times, since scaling the ingestors didn't seem to help.

it also pins the number of data nodes in development to 5 (which is the current number) because that seems more than sufficient. 

# security considerations
None.