### PR TITLE
resize dev to be single instance since there's no traffic.

### DIFF
--- a/logsearch-development.yml
+++ b/logsearch-development.yml
@@ -8,7 +8,7 @@ instance_groups:
     - (( grab terraform_outputs.logsearch_static_ips.[0]))
 
 - name: elasticsearch_data
-  instances: 3
+  instances: 1
 
 - name: archiver
   instances: 1

--- a/logsearch-platform-development.yml
+++ b/logsearch-platform-development.yml
@@ -23,8 +23,7 @@ instance_groups:
       redirect_url: https://logs-platform.dev.us-gov-west-1.aws-us-gov.cloud.gov/oauth2/callback
 
 - name: ingestor
-  instances: 3
-
+  instances: 1
 
 - name: elasticsearch_data
-  instances: 5
+  instances: 1


### PR DESCRIPTION
## Changes
- Scale dev to 1 of each instance since there's essentially no traffic.

## Security Considerations

None, scaling change.

Signed-off-by: Mike Lloyd <mike.lloyd@gsa.gov>