### PR TITLE
fixed scale due to default replica count.

### DIFF
--- a/logsearch-development.yml
+++ b/logsearch-development.yml
@@ -8,7 +8,8 @@ instance_groups:
     - (( grab terraform_outputs.logsearch_static_ips.[0]))
 
 - name: elasticsearch_data
-  instances: 1
+  instances: 3
+  instance_type: t3.medium
 
 - name: archiver
   instances: 1

--- a/logsearch-platform-development.yml
+++ b/logsearch-platform-development.yml
@@ -26,4 +26,5 @@ instance_groups:
   instances: 1
 
 - name: elasticsearch_data
-  instances: 1
+  instances: 3
+  instance_type: t3.medium


### PR DESCRIPTION
Just have to fix scaling as the default replica count is 5, so we need to have enough nodes to cover that. These are small burstable nodes, so it should be fine.

## Security Considerations

None.

Signed-off-by: Mike Lloyd <mike.lloyd@gsa.gov>