### PR TITLE
vm type resets.

### DIFF
--- a/logsearch-development.yml
+++ b/logsearch-development.yml
@@ -1,5 +1,6 @@
 instance_groups:
 - name: elasticsearch_master
+  vm_type: t3.medium
   instances: 1
   networks:
   - name: services
@@ -9,9 +10,14 @@ instance_groups:
 
 - name: elasticsearch_data
   instances: 3
-  instance_type: t3.medium
+  vm_type: t3.medium
+
+- name: redis
+  instances: 1
+  vm_type: t3.nano
 
 - name: archiver
+  vm_type: t3.small
   instances: 1
   jobs:
   - name: ingestor_cloudfoundry-firehose
@@ -20,6 +26,7 @@ instance_groups:
         api_endpoint: https://api.dev.us-gov-west-1.aws-us-gov.cloud.gov
 
 - name: ingestor
+  vm_type: t3.small
   instances: 1
   jobs:
   - name: ingestor_cloudfoundry-firehose
@@ -28,6 +35,7 @@ instance_groups:
         api_endpoint: https://api.dev.us-gov-west-1.aws-us-gov.cloud.gov
 
 - name: kibana
+  vm_type: t3.small
   instances: 1
   jobs:
   - name: kibana-auth-plugin

--- a/logsearch-jobs.yml
+++ b/logsearch-jobs.yml
@@ -39,7 +39,6 @@ instance_groups:
         - (( concat "suppress gen_id 1, sig_id 343080004, track by_src, ip " instance_groups.maintenance.networks.services.static_ips.[0] ))
         - 'alert tcp any any -> any 9200 (msg:"Unexpected logsearch action"; content:"DELETE"; http_method; content: "logs-platform"; http_uri; classtype:web-application-attack; sid:343080005; rev:1;)'
         - (( concat "suppress gen_id 1, sig_id 343080005, track by_src, ip " instance_groups.maintenance.networks.services.static_ips.[0] ))
-  vm_type: logsearch_es_master
   persistent_disk_type: logsearch_es_master
   stemcell: default
   azs: [z1]
@@ -57,7 +56,6 @@ instance_groups:
   instances: 1
   jobs:
   - {name: redis, release: logsearch-for-cloudfoundry}
-  vm_type: logsearch_redis
   persistent_disk_type: logsearch_redis
   stemcell: default
   azs: [z1]
@@ -143,7 +141,6 @@ instance_groups:
           month: "*"
           wday: "*"
           user: root
-  vm_type: logsearch_maintenance
   stemcell: default
   azs: [z1]
   networks:
@@ -178,7 +175,6 @@ instance_groups:
         recovery:
           delay_allocation_restart: "15m"
         migrate_data_path: true
-  vm_type: logsearch_es_data
   persistent_disk_type: logsearch_es_data
   stemcell: default
   azs: [z1]
@@ -236,7 +232,6 @@ instance_groups:
             name: kibana-up
             script_path: /var/vcap/jobs/kibana/bin/post-start
           timeout: 1s
-  vm_type: logsearch_kibana
   stemcell: default
   azs: [z1]
   networks:
@@ -285,7 +280,6 @@ instance_groups:
       syslog:
         host: 127.0.0.1
         port: 5514
-  vm_type: logsearch_ingestor
   persistent_disk_type: logsearch_ingestor
   stemcell: default
   azs: [z1]
@@ -338,7 +332,6 @@ instance_groups:
         port: 5514
   - name: parser-config-lfc
     release: logsearch-for-cloudfoundry
-  vm_type: logsearch_ingestor
   persistent_disk_type: logsearch_ingestor
   stemcell: default
   azs: [z1]
@@ -350,7 +343,6 @@ instance_groups:
 ###########################
 - name: smoke-tests
   instances: 1
-  vm_type: errand_small
   vm_extensions: [errand-profile]
   stemcell: default
   azs: [z1]

--- a/logsearch-platform-development.yml
+++ b/logsearch-platform-development.yml
@@ -1,6 +1,7 @@
 instance_groups:
 - name: elasticsearch_master
   instances: 1
+  vm_type: t3.medium
   networks:
   - name: services
     static_ips:
@@ -8,6 +9,7 @@ instance_groups:
     - (( grab terraform_outputs.logsearch_static_ips.[7]))
 
 - name: maintenance
+  vm_type: t3.small
   jobs:
   - name: curator
     properties:
@@ -16,6 +18,7 @@ instance_groups:
           retention_period: 7
 
 - name: kibana
+  vm_type: t3.small
   instances: 1
   jobs:
   - name: oauth2-proxy
@@ -24,7 +27,12 @@ instance_groups:
 
 - name: ingestor
   instances: 1
+  vm_type: t3.small
 
 - name: elasticsearch_data
   instances: 3
-  instance_type: t3.medium
+  vm_type: t3.medium
+
+- name: redis
+  instances: 1
+  vm_type: t3.nano

--- a/logsearch-platform-production.yml
+++ b/logsearch-platform-production.yml
@@ -1,10 +1,19 @@
 instance_groups:
+- name: elasticsearch_master
+  vm_type: t2.xlarge
+
+- name: maintenance
+  vm_type: t2.large
+
 - name: kibana
+  vm_type: t2.large
   jobs:
   - name: oauth2-proxy
     properties:
       redirect_url: https://logs-platform.fr.cloud.gov/oauth2/callback
+
 - name: ingestor
+  vm_type: r4.large
   jobs:
   - name: ingestor_syslog
     properties:
@@ -12,3 +21,9 @@ instance_groups:
         health:
           timeout: 900
 
+- name: elasticsearch_data
+  vm_type: r4.xlarge
+
+- name: redis
+  instances: 1
+  vm_type: t2.medium

--- a/logsearch-platform-staging.yml
+++ b/logsearch-platform-staging.yml
@@ -1,8 +1,22 @@
 instance_groups:
+- name: elasticsearch_master
+  vm_type: t3.large
+
 - name: elasticsearch_data
   instances: 4
+  vm_type: t2.medium
+
+- name: redis
+  vm_type: r4.large
+
+- name: ingestor
+  vm_type: t2.large
+
+- name: maintenance
+  vm_type: t2.large
 
 - name: kibana
+  vm_type: t2.large
   jobs:
   - name: oauth2-proxy
     properties:

--- a/logsearch-production.yml
+++ b/logsearch-production.yml
@@ -1,6 +1,16 @@
 instance_groups:
+- name: elasticsearch_master
+  vm_type: t2.xlarge
+
+- name: elasticsearch_data
+  vm_type: r4.xlarge
+
+- name: redis
+  vm_type: t2.medium
+
 - name: archiver
   instances: 3
+  vm_types: r4.large
   jobs:
   - name: ingestor_cloudfoundry-firehose
     properties:
@@ -9,6 +19,7 @@ instance_groups:
 
 - name: ingestor
   instances: 5
+  vm_type: r4.large
   jobs:
   - name: ingestor_cloudfoundry-firehose
     properties:
@@ -16,6 +27,7 @@ instance_groups:
         api_endpoint: https://api.fr.cloud.gov
 
 - name: kibana
+  vm_type: t2.large
   jobs:
   - name: kibana-auth-plugin
     properties:

--- a/logsearch-staging.yml
+++ b/logsearch-staging.yml
@@ -1,9 +1,17 @@
 instance_groups:
+- name: elasticsearch_master
+  vm_type: t3.medium
+
 - name: elasticsearch_data
   instances: 3
+  vm_type: t2.large
+
+- name: redis
+  vm_type: t2.medium
 
 - name: archiver
   instances: 1
+  vm_type: r4.large
   jobs:
   - name: ingestor_cloudfoundry-firehose
     properties:
@@ -12,6 +20,7 @@ instance_groups:
 
 - name: ingestor
   instances: 1
+  vm_type: r4.large
   jobs:
   - name: ingestor_cloudfoundry-firehose
     properties:
@@ -19,6 +28,7 @@ instance_groups:
         api_endpoint: https://api.fr-stage.cloud.gov
 
 - name: kibana
+  vm_type: t2.large
   jobs:
   - name: kibana-auth-plugin
     properties:


### PR DESCRIPTION
## Changes

* **Does**
  * Explicitly set vm types to new values - reset the vm type alias to align with AWS instance type names.
  * Change vm types in _development_
* **Does Not**
  * Change vm types in _staging_ or _production_
  * Change scaling in _staging_ or _production_

## Security Considerations

None
