### PR TITLE
let the job figure out how much heap based on available memory

### DIFF
--- a/logsearch-jobs.yml
+++ b/logsearch-jobs.yml
@@ -72,7 +72,6 @@ instance_groups:
       elasticsearch: {from: elasticsearch_master}
     properties:
       elasticsearch:
-        heap_size: 2G
         migrate_data_path: true
   - name: curator
     release: logsearch
@@ -248,7 +247,6 @@ instance_groups:
       elasticsearch: {from: elasticsearch_master}
     properties:
       elasticsearch:
-        heap_size: 1G
         migrate_data_path: true
   - name: archiver_syslog
     release: logsearch


### PR DESCRIPTION
# Changes proposed in this PR
- Stop pinning the memory usage on maintenance and archiver nodes. By not specifying a heap, the heap will be set to 46% of the available memory

# Security Considerations
none